### PR TITLE
✨Feat(#24): 모임 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -2,6 +2,7 @@ package com.runto.domain.gathering.api;
 
 import com.runto.domain.gathering.application.GatheringService;
 import com.runto.domain.gathering.dto.CreateGatheringRequest;
+import com.runto.domain.gathering.dto.GatheringDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,12 @@ public class GatheringController {
 
         gatheringService.createGatheringGeneral(request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{gathering_id}")
+    public ResponseEntity<GatheringDetailResponse> getGatheringDetail(
+            @PathVariable("gathering_id") Long gatheringId) {
+        return ResponseEntity.ok(gatheringService.getGatheringDetail(gatheringId));
     }
 
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
+
 @Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -30,13 +32,15 @@ public class GatheringService {
 
 
     // TODO: 회원관련 기능 dev에 머지되면 param 에 UserDetails 추가 & 교체 , user 관련 예외로 수정
+    // TODO: 만약 신고기능 구현하는거면 나중에 관련 로직 추가 필요
     @Transactional
     public void createGatheringGeneral(CreateGatheringRequest request) {
 
-        User findUser = userRepository.findById(1L)
+        User user = userRepository.findById(1L)
                 .orElseThrow(() -> new RuntimeException("없는 유저"));
 
-        Gathering gathering = request.toEntity(findUser);
+        Gathering gathering = request.toEntity(user);
+        gathering.addMember(user, ORGANIZER);
         addContentImages(request.getGatheringImageUrls(), gathering);
 
         gatheringRepository.save(gathering);
@@ -48,7 +52,7 @@ public class GatheringService {
     }
 
     private void addContentImages(GatheringImageUrlsDto imageUrlDto, Gathering gathering) {
-        if(imageUrlDto == null) return;
+        if (imageUrlDto == null) return;
 
         List<GatheringImage> gatheringImages = imageUrlDto.getContentImageUrls().stream()
                 .map(ImageUrlDto::toEntity)

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
@@ -36,11 +37,14 @@ public class GatheringService {
 
     // TODO: 회원관련 기능 dev에 머지되면 param 에 UserDetails 추가 & 교체 , user 관련 예외로 수정
     // TODO: 만약 신고기능 구현하는거면 나중에 관련 로직 추가 필요
+    // TODO: 날짜 설정 검증 로직 필요 (설정 날짜 관련 서비스 정책? 정하고 추후에 추가)
     @Transactional
     public void createGatheringGeneral(CreateGatheringRequest request) {
 
         User user = userRepository.findById(1L)
                 .orElseThrow(() -> new RuntimeException("없는 유저"));
+
+        validateDate(request.getDeadline(), request.getAppointedAt());
 
         Gathering gathering = request.toEntity(user);
         gathering.addMember(user, ORGANIZER);
@@ -52,6 +56,11 @@ public class GatheringService {
         // TODO moveImageProcess 에러 해결되면 주석 풀기
 //        imageService.moveImageFromTempToPermanent(request.getGatheringImageUrls()
 //                .getContentImageUrls());
+    }
+    
+    // TODO: 설정 날짜 관련 서비스 정책? 정하고 구현
+    private void validateDate(LocalDateTime deadLine, LocalDateTime appointedAt) {
+        return;
     }
 
     private void addContentImages(GatheringImageUrlsDto imageUrlDto, Gathering gathering) {

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -4,6 +4,8 @@ package com.runto.domain.gathering.application;
 import com.runto.domain.gathering.dao.GatheringRepository;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.dto.CreateGatheringRequest;
+import com.runto.domain.gathering.dto.GatheringDetailResponse;
+import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.image.application.ImageService;
 import com.runto.domain.image.domain.GatheringImage;
 import com.runto.domain.image.dto.GatheringImageUrlsDto;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
+import static com.runto.global.exception.ErrorCode.GATHERING_NOT_FOUND;
 
 @Slf4j
 @Transactional(readOnly = true)
@@ -58,5 +61,13 @@ public class GatheringService {
                 .map(ImageUrlDto::toEntity)
                 .toList();
         gathering.addContentImages(gatheringImages);
+    }
+
+    public GatheringDetailResponse getGatheringDetail(Long gatheringId) {
+
+        Gathering gathering = gatheringRepository.findGatheringDetailById(gatheringId)
+                .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
+
+        return GatheringDetailResponse.from(gathering);
     }
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -38,6 +38,7 @@ public class GatheringService {
     // TODO: 회원관련 기능 dev에 머지되면 param 에 UserDetails 추가 & 교체 , user 관련 예외로 수정
     // TODO: 만약 신고기능 구현하는거면 나중에 관련 로직 추가 필요
     // TODO: 날짜 설정 검증 로직 필요 (설정 날짜 관련 서비스 정책? 정하고 추후에 추가)
+    // TODO: 그룹 채팅방 생성 로직 추가
     @Transactional
     public void createGatheringGeneral(CreateGatheringRequest request) {
 

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
@@ -3,8 +3,18 @@ package com.runto.domain.gathering.dao;
 
 import com.runto.domain.gathering.domain.Gathering;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface GatheringRepository extends JpaRepository<Gathering, Long> {
+
+    @Query("select g from Gathering g " +
+            " join fetch g.gatheringMembers gm " +
+            " join fetch gm.user " +
+            " where g.id= :gathering_id ")
+    Optional<Gathering> findGatheringDetailById(@Param("gathering_id") Long gatheringId);
 }

--- a/src/main/java/com/runto/domain/gathering/domain/Coordinates.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Coordinates.java
@@ -4,8 +4,10 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Builder
 @AllArgsConstructor
 @Embeddable

--- a/src/main/java/com/runto/domain/gathering/domain/Gathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Gathering.java
@@ -1,12 +1,12 @@
 package com.runto.domain.gathering.domain;
 
 import com.runto.domain.common.BaseTimeEntity;
+import com.runto.domain.gathering.dto.GatheringMember;
 import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.gathering.type.GatheringStatus;
 import com.runto.domain.gathering.type.GoalDistance;
 import com.runto.domain.gathering.type.RunningConcept;
 import com.runto.domain.image.domain.GatheringImage;
-import com.runto.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +19,6 @@ import java.util.List;
 
 import static com.runto.domain.gathering.type.GatheringStatus.NORMAL;
 import static com.runto.global.exception.ErrorCode.*;
-import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Builder
@@ -37,8 +36,9 @@ public class Gathering extends BaseTimeEntity {
     @Column(name = "gathering_id")
     private Long id;
 
-    @ManyToOne(fetch = LAZY)
-    private User host;
+    // 주최자 닉네임 반정규화는 보류
+    @Column(name = "organizer_id", nullable = false)
+    private Long organizerId;
 
     @Column(nullable = false, length = 30)
     private String title;
@@ -81,6 +81,10 @@ public class Gathering extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "gathering", cascade = CascadeType.PERSIST)
     private List<GatheringImage> contentImages = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "gathering", cascade = CascadeType.ALL)
+    private List<GatheringMember> gatheringMembers = new ArrayList<>();
 
 
     // 양방향관계,영속성전이를 통한 저장방식, 엔티티에서 dto를 참조하지 않는 구조를 고려하여 만들었음

--- a/src/main/java/com/runto/domain/gathering/domain/Gathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Gathering.java
@@ -3,10 +3,13 @@ package com.runto.domain.gathering.domain;
 import com.runto.domain.common.BaseTimeEntity;
 import com.runto.domain.gathering.dto.GatheringMember;
 import com.runto.domain.gathering.exception.GatheringException;
+import com.runto.domain.gathering.type.GatheringMemberRole;
 import com.runto.domain.gathering.type.GatheringStatus;
 import com.runto.domain.gathering.type.GoalDistance;
 import com.runto.domain.gathering.type.RunningConcept;
 import com.runto.domain.image.domain.GatheringImage;
+import com.runto.domain.user.domain.User;
+import com.runto.domain.user.type.UserStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.runto.domain.gathering.type.GatheringStatus.NORMAL;
-import static com.runto.global.exception.ErrorCode.*;
+import static com.runto.global.exception.ErrorCode.IMAGE_SAVE_LIMIT_EXCEEDED;
+import static com.runto.global.exception.ErrorCode.USER_INACTIVE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Builder
@@ -79,7 +83,7 @@ public class Gathering extends BaseTimeEntity {
     private Integer currentNumber;
 
     @Builder.Default
-    @OneToMany(mappedBy = "gathering", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "gathering", cascade = CascadeType.ALL)
     private List<GatheringImage> contentImages = new ArrayList<>();
 
     @Builder.Default
@@ -100,6 +104,13 @@ public class Gathering extends BaseTimeEntity {
             image.assignGathering(this);
             this.contentImages.add(image);
         });
+    }
+
+    public void addMember(User user, GatheringMemberRole role) {
+        if (!UserStatus.ACTIVE.equals(user.getStatus())) {
+            throw new GatheringException(USER_INACTIVE);
+        }
+        gatheringMembers.add(GatheringMember.of(this, user, role));
     }
 
 

--- a/src/main/java/com/runto/domain/gathering/domain/Location.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Location.java
@@ -5,8 +5,10 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -18,4 +20,11 @@ public class Location {
 
     @Embedded
     private Coordinates coordinates;
+
+    public static Location of(String addressName, double x, double y) {
+        return Location.builder()
+                .addressName(addressName)
+                .coordinates(new Coordinates(x, y))
+                .build();
+    }
 }

--- a/src/main/java/com/runto/domain/gathering/dto/CoordinatesDto.java
+++ b/src/main/java/com/runto/domain/gathering/dto/CoordinatesDto.java
@@ -2,8 +2,14 @@ package com.runto.domain.gathering.dto;
 
 import com.runto.domain.gathering.domain.Coordinates;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class CoordinatesDto {
 
@@ -12,6 +18,13 @@ public class CoordinatesDto {
 
     @NotNull(message = "y값은 필수입니다.")
     private Double y;
+
+    public static CoordinatesDto from(Coordinates coordinates) {
+        return CoordinatesDto.builder()
+                .x(coordinates.getX())
+                .y(coordinates.getY())
+                .build();
+    }
 
     public Coordinates toCoordinates() {
         return new Coordinates(x, y);

--- a/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
+++ b/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
@@ -50,10 +50,10 @@ public class CreateGatheringRequest {
     @Valid
     private GatheringImageUrlsDto gatheringImageUrls;
 
-    public Gathering toEntity(User host) {
+    public Gathering toEntity(User organizer) {
 
         return Gathering.builder()
-                .host(host)
+                .organizerId(organizer.getId())
                 .title(title)
                 .description(description)
                 .appointedAt(appointedAt)

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringDetailResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringDetailResponse.java
@@ -1,0 +1,33 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.domain.Gathering;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+@Getter
+public class GatheringDetailResponse {
+
+    private GatheringResponse gatheringResponse;
+    private List<GatheringMemberResponse> gatheringMembers;
+
+
+    public static GatheringDetailResponse from(Gathering gathering) { // 패치 조인 해온 모임글
+
+        return GatheringDetailResponse.builder()
+                .gatheringResponse(GatheringResponse.from(gathering))
+                .gatheringMembers(GatheringMemberResponse.from(gathering.getGatheringMembers()))
+                .build();
+    }
+
+}

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
@@ -35,6 +35,14 @@ public class GatheringMember extends BaseTimeEntity {
     @Column(name = "gathering_member_role")
     private GatheringMemberRole role;
 
+    public static GatheringMember of(Gathering gathering, User user, GatheringMemberRole role) {
+        return GatheringMember.builder()
+                .gathering(gathering)
+                .user(user)
+                .role(role)
+                .build();
+    }
+
     @PrePersist
     public void prePersist() {
         attendanceStatus = AttendanceStatus.PENDING;

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
@@ -1,0 +1,43 @@
+package com.runto.domain.gathering.dto;
+
+import com.runto.domain.common.BaseTimeEntity;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.type.AttendanceStatus;
+import com.runto.domain.gathering.type.GatheringMemberRole;
+import com.runto.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class GatheringMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "gathering_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Gathering gathering;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "attendance_status")
+    private AttendanceStatus attendanceStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gathering_member_role")
+    private GatheringMemberRole role;
+
+    @PrePersist
+    public void prePersist() {
+        attendanceStatus = AttendanceStatus.PENDING;
+    }
+
+}

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringMemberResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringMemberResponse.java
@@ -1,0 +1,39 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+public class GatheringMemberResponse {
+
+    private Long gatheringMemberId;
+    private String nickname;
+    private String profileImageUrl;
+
+    public static List<GatheringMemberResponse> from(List<GatheringMember> gatheringMembers) {
+
+        return gatheringMembers.stream()
+                .map(GatheringMemberResponse::from)
+                .toList();
+    }
+
+    public static GatheringMemberResponse from(GatheringMember gatheringMember) {
+
+        return GatheringMemberResponse.builder()
+                .gatheringMemberId(gatheringMember.getId())
+                .nickname(gatheringMember.getUser().getNickname())
+                .profileImageUrl(gatheringMember.getUser().getProfileImageUrl())
+                .build();
+    }
+
+}

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringMemberResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringMemberResponse.java
@@ -2,6 +2,7 @@ package com.runto.domain.gathering.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.type.GatheringMemberRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class GatheringMemberResponse {
     private Long gatheringMemberId;
     private String nickname;
     private String profileImageUrl;
+    private GatheringMemberRole role;
 
     public static List<GatheringMemberResponse> from(List<GatheringMember> gatheringMembers) {
 
@@ -33,6 +35,7 @@ public class GatheringMemberResponse {
                 .gatheringMemberId(gatheringMember.getId())
                 .nickname(gatheringMember.getUser().getNickname())
                 .profileImageUrl(gatheringMember.getUser().getProfileImageUrl())
+                .role(gatheringMember.getRole())
                 .build();
     }
 

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringResponse.java
@@ -1,0 +1,69 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.type.GatheringStatus;
+import com.runto.domain.gathering.type.GoalDistance;
+import com.runto.domain.gathering.type.RunningConcept;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+public class GatheringResponse {
+
+    private Long id;
+
+    private Long organizerId;
+
+    private String title;
+
+    private String description;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime appointedAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime deadline;
+
+    private RunningConcept concept;
+
+    private GoalDistance goalDistance;
+
+    private Long hits;
+
+    private LocationDto location;
+
+    private GatheringStatus status;
+
+    private Integer maxNumber;
+
+    private Integer currentNumber;
+
+    public static GatheringResponse from(Gathering gathering) {
+        return GatheringResponse.builder()
+                .id(gathering.getId())
+                .organizerId(gathering.getOrganizerId())
+                .title(gathering.getTitle())
+                .description(gathering.getDescription())
+                .appointedAt(gathering.getAppointedAt())
+                .deadline(gathering.getDeadline())
+                .concept(gathering.getConcept())
+                .goalDistance(gathering.getGoalDistance())
+                .hits(gathering.getHits())
+                .location(LocationDto.from(gathering.getLocation()))
+                .status(gathering.getStatus())
+                .maxNumber(gathering.getMaxNumber())
+                .currentNumber(gathering.getCurrentNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/runto/domain/gathering/dto/LocationDto.java
+++ b/src/main/java/com/runto/domain/gathering/dto/LocationDto.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.gathering.domain.Location;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LocationDto {
@@ -18,6 +22,13 @@ public class LocationDto {
 
     @NotNull(message = "위치 좌표는 필수값입니다.")
     private CoordinatesDto coordinates;
+
+    public static LocationDto from(Location location) {
+        return LocationDto.builder()
+                .addressName(location.getAddressName())
+                .coordinates(CoordinatesDto.from(location.getCoordinates()))
+                .build();
+    }
 
     public Location toLocation() {
         return Location.builder()

--- a/src/main/java/com/runto/domain/gathering/type/AttendanceStatus.java
+++ b/src/main/java/com/runto/domain/gathering/type/AttendanceStatus.java
@@ -1,0 +1,8 @@
+package com.runto.domain.gathering.type;
+
+public enum AttendanceStatus {
+
+    ATTENDING,   // 참석
+    NOT_ATTENDING, // 불참
+    PENDING      // 대기
+}

--- a/src/main/java/com/runto/domain/gathering/type/GatheringMemberRole.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringMemberRole.java
@@ -1,0 +1,7 @@
+package com.runto.domain.gathering.type;
+
+public enum GatheringMemberRole {
+
+    ORGANIZER, // 주최자
+    PARTICIPANT // 참여자
+}

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 
 
     USER_NOT_FOUND(NOT_FOUND,"존재하지 않는 유저입니다." ),
+    USER_INACTIVE(FORBIDDEN,"사용자가 비활성 상태입니다. 이 작업을 수행할 수 없습니다."),
 
     // 채팅관련,
     CHATROOM_ALREADY_EXIST(CONFLICT,"이미 존재하는 채팅방입니다."),

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(NOT_FOUND,"존재하지 않는 유저입니다." ),
     USER_INACTIVE(FORBIDDEN,"사용자가 비활성 상태입니다. 이 작업을 수행할 수 없습니다."),
 
+    // 모임글 & 이벤트 관련
+    GATHERING_NOT_FOUND(NOT_FOUND, "존재하지 않는 모임글입니다."),
+
     // 채팅관련,
     CHATROOM_ALREADY_EXIST(CONFLICT,"이미 존재하는 채팅방입니다."),
     CHATROOM_NOT_FOUND(NOT_FOUND,"존재하지 않는 채팅방입니다."),


### PR DESCRIPTION
 <br/>

## 🔎 작업 내용

### **모임 상세 조회 기능 구현**
  모임 id(pk)를 통해 특정 모임을 상세조회 시 아래 데이터들을 조회한다.
  -  모임 자체에 대한 데이터 
  -  해당 모임에 속한 멤버목록 (pk, 닉네임, 프로필이미지)

### **연관관계 설계 수정**


- ### 수정이유
  `` Gathering / User(주최자) / GatheringApplicants (지원자들) - Users `` 를 한번에 패치조인해올 예정이었으나, 
   ```
   @Query("select g from Gathering g " +
            " join fetch g.host h " +
            " join fetch g.gatheringApplicants ga " + 
            " join fetch ga.user " +
            " where g.id= :gathering_id ")
    Optional<Gathering> findGatheringDetailById(@Param("gathering_id") Long gatheringId);
   ```
  계속 가지고오는 엔티티가 null인 상황이었습니다.
  db에 데이터가 제대로 있는지, 연관관계 등에서 실수한 점은 없는지, jpql문 자체에 문제는 없는지 확인했으나
  계속 검토해본 결과 문제가 없다고 판단했습니다.

  찾아보고 테스트해본 결과 패치조인해서 같이 들고오는 gatheringApplicants 데이터 자체가 하나도 없으면 아예 Gathering 을 
  들고오지 못하는 상태였습니다.

  조회하는 Gathering 에 gatheringApplicants가 하나도 없어도 정상동작할거라고 생각한 이유는
  어차피 들고오는 메인 엔티티는 Gathering 이고, (where문의 조건도 Gathering 에 대한 관한 것이기도 하고..)
  가지고올 땐, Gathering  안의 필드에 넣어서 가지고 오니까..
  
  gatheringApplicants가 없으면 그냥 그 부분만 값을 안 넣은채로 Gathering 엔티티를 가지고 올 수 있을 줄 알았습니다.
 패치조인에 대해 이해가 부족했던 것 같습니다.. (이 부분 때문에 아예 Gathering 을 안 가지고 올 줄이야..)

### -> 나중에 보니까 inner join 이어서 생긴 문제였습니다.
  
   ```
      패치조인을 써서 조회를 해야 하는데, 기존 설계 구조는 GatheringApplicant 에는 주최자가 들어가지 않는 구조로,
      다른 유저가 참여를 하기 전까지는 해당 모임에 속한 GatheringApplicant  데이터가 하나도 없어서 
      패치조인이 불가한 상황, 하지만 참여를 하려면 상세조회를 통해서 들어가야하는 상황.. 
   ```

- ### 수정사항
    - **Gathering 과 User (주최자) 연관관계 삭제**
    - **GatheringApplicant -> GatheringMember 으로 수정**
      -  기존의 GatheringApplicant 은 주최자를 제외한 지원자만 포함하는 테이블이었음
         (주최자에 대한 데이터는 연관관계를 맺은 상태)
      -  Gathering 과 User (주최자) 연관관계 삭제를 하게됨으로써 GatheringApplicant 에도 주최자의 데이터를 넣게됨
        - 지원자라는 국한된 의미가 아닌 모임의 모든 구성원이라는 의미를 담기 위해 GatheringMember로 수정 
        - GatheringMemberRole 로 구분  ``ORGANIZER(주최자),  PARTICIPANT(참여자)``
    - **조회 시 성능의 문제때문에 ORGANIZER에 대한 pk값을 Gathering 에 반정규화** 
      -  나중에 닉네임에 대해서도 반정규화를 하게 될 수도 있음(고민중)
      -  이 부분들을 어떻게 관리해야할지에 대한 고민 필요

## 📷 이미지
### 변경 erd 참고

### before
![image](https://github.com/user-attachments/assets/fda2b660-95e0-4bb5-be40-5759215efd5c)

### after
![image](https://github.com/user-attachments/assets/dc8ef3ab-8f17-43d2-a61f-5dfe3172a3aa)



  <br/>


<br/>

## 🔧 리뷰 요구사항
  수정하게 된 과정, 이유 &  예전 설계 과정과 이유는 노션에 올려놨긴했는데, 
  정제된 느낌이 아닌 주저리 주저리 작성해놓은거라 수정할 예정입니다..
   pr엔 수정하는 이유, 수정사항만 올리겠습니다.


<br/>
closed #24 