### PR TITLE
✨ Feat(#30): 모임글 이미지목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -8,7 +8,7 @@ import com.runto.domain.gathering.dto.GatheringDetailResponse;
 import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.image.application.ImageService;
 import com.runto.domain.image.domain.GatheringImage;
-import com.runto.domain.image.dto.GatheringImageUrlsDto;
+import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUrlDto;
 import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.User;
@@ -49,7 +49,7 @@ public class GatheringService {
 
         Gathering gathering = request.toEntity(user);
         gathering.addMember(user, ORGANIZER);
-        addContentImages(request.getGatheringImageUrls(), gathering);
+        addContentImages(request.getImageRegisterResponse(), gathering);
 
         gatheringRepository.save(gathering);
 
@@ -64,7 +64,7 @@ public class GatheringService {
         return;
     }
 
-    private void addContentImages(GatheringImageUrlsDto imageUrlDto, Gathering gathering) {
+    private void addContentImages(ImageRegisterResponse imageUrlDto, Gathering gathering) {
         if (imageUrlDto == null) return;
 
         List<GatheringImage> gatheringImages = imageUrlDto.getContentImageUrls().stream()

--- a/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
+++ b/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.type.GoalDistance;
 import com.runto.domain.gathering.type.RunningConcept;
-import com.runto.domain.image.dto.GatheringImageUrlsDto;
+import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.user.domain.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -48,7 +48,7 @@ public class CreateGatheringRequest {
     private RunningConcept concept;
 
     @Valid
-    private GatheringImageUrlsDto gatheringImageUrls;
+    private ImageRegisterResponse imageRegisterResponse;
 
     public Gathering toEntity(User organizer) {
 
@@ -60,7 +60,7 @@ public class CreateGatheringRequest {
                 .deadline(deadline)
                 .concept(concept)
                 .goalDistance(goalDistance)
-                .thumbnailUrl(gatheringImageUrls.getRepresentativeImageUrl())
+                .thumbnailUrl(imageRegisterResponse.getRepresentativeImageUrl())
                 .location(location.toLocation())
                 .maxNumber(maxNumber)
                 .build();

--- a/src/main/java/com/runto/domain/image/api/ImageController.java
+++ b/src/main/java/com/runto/domain/image/api/ImageController.java
@@ -27,4 +27,11 @@ public class ImageController {
         return ResponseEntity.ok(imageService.registerGatheringImages(
                 ImageUploadRequest.of(representativeImageIndex, images, imageOrder)));
     }
+
+    @GetMapping
+    public ResponseEntity<ImageUrlsResponse> getGatheringImages(
+            @RequestParam("gathering_id") Long gatheringId) {
+
+        return ResponseEntity.ok(imageService.getGatheringImages(gatheringId));
+    }
 }

--- a/src/main/java/com/runto/domain/image/api/ImageController.java
+++ b/src/main/java/com/runto/domain/image/api/ImageController.java
@@ -1,14 +1,12 @@
 package com.runto.domain.image.api;
 
 import com.runto.domain.image.application.ImageService;
-import com.runto.domain.image.dto.GatheringImageUrlsDto;
+import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUploadRequest;
+import com.runto.domain.image.type.ImageUrlsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -21,7 +19,7 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping("/gathering")
-    public ResponseEntity<GatheringImageUrlsDto> registerGatheringImages(
+    public ResponseEntity<ImageRegisterResponse> registerGatheringImages(
             @RequestPart(value = "representative_image_index", required = false) Integer representativeImageIndex,
             @RequestPart(value = "images", required = false) List<MultipartFile> images,
             @RequestPart(value = "image_order", required = false) int[] imageOrder) { // 안에 하나하나 null 체크 하는 것보다 0으로 받기로 함

--- a/src/main/java/com/runto/domain/image/application/ImageService.java
+++ b/src/main/java/com/runto/domain/image/application/ImageService.java
@@ -19,7 +19,7 @@ public class ImageService {
 
     public ImageRegisterResponse registerGatheringImages(ImageUploadRequest uploadRequest) {
 
-        if(uploadRequest == null) return null;
+        if (uploadRequest == null) return null;
 
         List<ImageUrlDto> contentImageUrls = s3GatheringImageService
                 .uploadContentImages(uploadRequest.getImages());
@@ -30,10 +30,18 @@ public class ImageService {
 
     public void moveImageFromTempToPermanent(List<ImageUrlDto> contentImageUrls) {
 
-        if(contentImageUrls == null || contentImageUrls.isEmpty()) return;
+        if (contentImageUrls == null || contentImageUrls.isEmpty()) return;
 
         contentImageUrls.forEach(imageUrlDto ->
                 s3GatheringImageService.moveImageProcess(imageUrlDto.getImageUrl()));
+    }
+
+    public ImageUrlsResponse getGatheringImages(Long gatheringId) {
+
+        return new ImageUrlsResponse(
+                gatheringImageRepository.findGatheringImagesByGatheringId(gatheringId).stream()
+                        .map(ImageUrlDto::from)
+                        .toList());
     }
 
 }

--- a/src/main/java/com/runto/domain/image/application/ImageService.java
+++ b/src/main/java/com/runto/domain/image/application/ImageService.java
@@ -1,8 +1,10 @@
 package com.runto.domain.image.application;
 
-import com.runto.domain.image.dto.GatheringImageUrlsDto;
+import com.runto.domain.image.dao.GatheringImageRepository;
+import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUploadRequest;
 import com.runto.domain.image.dto.ImageUrlDto;
+import com.runto.domain.image.type.ImageUrlsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,15 +15,16 @@ import java.util.List;
 public class ImageService {
 
     private final S3GatheringImageService s3GatheringImageService;
+    private final GatheringImageRepository gatheringImageRepository;
 
-    public GatheringImageUrlsDto registerGatheringImages(ImageUploadRequest uploadRequest) {
+    public ImageRegisterResponse registerGatheringImages(ImageUploadRequest uploadRequest) {
 
         if(uploadRequest == null) return null;
 
         List<ImageUrlDto> contentImageUrls = s3GatheringImageService
                 .uploadContentImages(uploadRequest.getImages());
 
-        return GatheringImageUrlsDto.of(
+        return ImageRegisterResponse.of(
                 uploadRequest.getRepresentativeImageIndex(), contentImageUrls);
     }
 
@@ -32,4 +35,5 @@ public class ImageService {
         contentImageUrls.forEach(imageUrlDto ->
                 s3GatheringImageService.moveImageProcess(imageUrlDto.getImageUrl()));
     }
+
 }

--- a/src/main/java/com/runto/domain/image/dao/GatheringImageRepository.java
+++ b/src/main/java/com/runto/domain/image/dao/GatheringImageRepository.java
@@ -1,0 +1,13 @@
+package com.runto.domain.image.dao;
+
+import com.runto.domain.image.domain.GatheringImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GatheringImageRepository extends JpaRepository<GatheringImage, Long> {
+
+    List<GatheringImage> findGatheringImagesByGatheringId(Long gatheringId);
+}

--- a/src/main/java/com/runto/domain/image/domain/GatheringImage.java
+++ b/src/main/java/com/runto/domain/image/domain/GatheringImage.java
@@ -5,12 +5,14 @@ import com.runto.domain.gathering.domain.Gathering;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)

--- a/src/main/java/com/runto/domain/image/dto/ImageRegisterResponse.java
+++ b/src/main/java/com/runto/domain/image/dto/ImageRegisterResponse.java
@@ -17,7 +17,7 @@ import static com.runto.global.exception.ErrorCode.INVALID_REPRESENTATIVE_IMAGE_
 @AllArgsConstructor
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class GatheringImageUrlsDto {
+public class ImageRegisterResponse {
 
     private Integer representativeImageIndex;
 
@@ -25,7 +25,7 @@ public class GatheringImageUrlsDto {
     @Size(max = 3, message = "이미지 등록은 최대 3개까지만 허용됩니다.")
     private List<ImageUrlDto> contentImageUrls;
 
-    public static GatheringImageUrlsDto of(Integer representativeImageIndex, List<ImageUrlDto> imageUrls) {
+    public static ImageRegisterResponse of(Integer representativeImageIndex, List<ImageUrlDto> imageUrls) {
 
         if (representativeImageIndex == null || representativeImageIndex < 0) {
             representativeImageIndex = 0;
@@ -34,11 +34,12 @@ public class GatheringImageUrlsDto {
             throw new ImageException(INVALID_REPRESENTATIVE_IMAGE_INDEX);
         }
 
-        return GatheringImageUrlsDto.builder()
+        return ImageRegisterResponse.builder()
                 .representativeImageIndex(representativeImageIndex)
                 .contentImageUrls(imageUrls)
                 .build();
     }
+
 
     public String getRepresentativeImageUrl() {
         return contentImageUrls

--- a/src/main/java/com/runto/domain/image/dto/ImageUrlDto.java
+++ b/src/main/java/com/runto/domain/image/dto/ImageUrlDto.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.image.domain.GatheringImage;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -18,6 +20,13 @@ public class ImageUrlDto {
     private String imageUrl;
 
     private int order;
+
+    public static ImageUrlDto from(GatheringImage image) {
+        return ImageUrlDto.builder()
+                .imageUrl(image.getImageUrl())
+                .order(image.getImageOrder())
+                .build();
+    }
 
     public GatheringImage toEntity() {
         return GatheringImage.builder()

--- a/src/main/java/com/runto/domain/image/type/ImageUrlsResponse.java
+++ b/src/main/java/com/runto/domain/image/type/ImageUrlsResponse.java
@@ -1,0 +1,17 @@
+package com.runto.domain.image.type;
+
+import com.runto.domain.image.dto.ImageUrlDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ImageUrlsResponse {
+
+    private List<ImageUrlDto> contentImageUrls;
+
+}


### PR DESCRIPTION
## 🔎 작업 내용

### 모임글 이미지 목록 조회 기능
  - **GatheringImageRepository**
     - ``List<GatheringImage> findGatheringImagesByGatheringId(Long gatheringId)``
  -  **ImageService**
     -   ``getGatheringImages(Long gatheringId)``
         - 반환 받은 ``List<GatheringImage>``를  ``ImageUrlDto`` 로 변환
         - ``ImageUrlsResponse`` 로 반환
  - **ImageController**
      - ``getGatheringImages``
        - ``@RequestParam("gathering_id") Long gatheringId``  를 통해 특정 gathering id 값을 받아온다.

### 모임글 이미지 업로드 관련(#5)  수정사항 c95f3e64 49a04069
    
   - ``GatheringImageUrlsDto`` -> ``ImageRegisterResponse`` 클래스이름 변경
  <br/>

<br/>

<br/>
closed: #30 