### PR TITLE
✨Feat(#10): 1:1 채팅방 생성 구현

### DIFF
--- a/src/main/java/com/runto/domain/chat/api/DirectChatController.java
+++ b/src/main/java/com/runto/domain/chat/api/DirectChatController.java
@@ -1,0 +1,29 @@
+package com.runto.domain.chat.api;
+
+import com.runto.domain.chat.application.DirectChatService;
+import com.runto.global.security.detail.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/chat/direct")
+@RequiredArgsConstructor
+public class DirectChatController {
+    private final DirectChatService directChatService;
+
+    //1:1 채팅방 생성 api
+    @PostMapping
+    public ResponseEntity<Void> createDirectChatRoom(@RequestParam(name = "other_id") Long otherId,
+                                               @AuthenticationPrincipal CustomUserDetails userDetails){
+        directChatService.createDirectChat(userDetails.getUsername(), otherId);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/runto/domain/chat/application/DirectChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/DirectChatService.java
@@ -1,0 +1,46 @@
+package com.runto.domain.chat.application;
+
+import com.runto.domain.chat.dao.DirectChatRoomRepository;
+import com.runto.domain.chat.domain.DirectChatRoom;
+import com.runto.domain.chat.exception.ChatException;
+import com.runto.domain.user.dao.UserRepository;
+import com.runto.domain.user.domain.User;
+import com.runto.domain.user.excepction.UserException;
+import com.runto.global.exception.ErrorCode;
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DirectChatService {
+    private final UserRepository userRepository;
+    private final DirectChatRoomRepository directChatRoomRepository;
+
+    @Transactional
+    public void createDirectChat(String email, Long otherId){
+        User me = userRepository.findByEmail(email)
+                .orElseThrow(()->new UserException(ErrorCode.USER_NOT_FOUND));
+        User otherUser = userRepository.findById(otherId)
+                .orElseThrow(()->new UserException(ErrorCode.USER_NOT_FOUND));
+
+        //동일한 아이디의 채팅방 생성 막기
+        if (me.getId().equals(otherUser.getId())){
+            throw new ChatException(ErrorCode.CHATROOM_CREATE_FAILED);
+        }
+
+        //A와 B의 채팅방이 이미 존재하는지 확인
+        if (directChatRoomRepository.existsByUserPair(me,otherUser)){
+            throw new ChatException(ErrorCode.CHATROOM_ALREADY_EXIST);
+        }
+
+        DirectChatRoom directChatRoom = DirectChatRoom.createRoom(me,otherUser);
+        try {
+            directChatRoomRepository.save(directChatRoom);
+        }catch (OptimisticLockException | DataIntegrityViolationException e){
+            throw new ChatException(ErrorCode.CHATROOM_ALREADY_EXIST);
+        }
+    }
+}

--- a/src/main/java/com/runto/domain/chat/application/DirectChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/DirectChatService.java
@@ -28,7 +28,7 @@ public class DirectChatService {
 
         //동일한 아이디의 채팅방 생성 막기
         if (me.getId().equals(otherUser.getId())){
-            throw new ChatException(ErrorCode.CHATROOM_CREATE_FAILED);
+            throw new ChatException(ErrorCode.CHATROOM_CREATE_FAILED_OWN);
         }
 
         //A와 B의 채팅방이 이미 존재하는지 확인

--- a/src/main/java/com/runto/domain/chat/dao/DirectChatRoomRepository.java
+++ b/src/main/java/com/runto/domain/chat/dao/DirectChatRoomRepository.java
@@ -1,0 +1,16 @@
+package com.runto.domain.chat.dao;
+
+import com.runto.domain.chat.domain.DirectChatRoom;
+import com.runto.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DirectChatRoomRepository extends JpaRepository<DirectChatRoom,Long> {
+
+    @Query("select count(dcr) > 0 from DirectChatRoom dcr " +
+            "where (dcr.user1 = :user1 and dcr.user2 = :user2) " +
+            "or (dcr.user1 = :user2 and  dcr.user2 = :user1)")
+    boolean existsByUserPair(@Param("user1")User user1, @Param("user2")User user2);
+
+}

--- a/src/main/java/com/runto/domain/chat/domain/DirectChatRoom.java
+++ b/src/main/java/com/runto/domain/chat/domain/DirectChatRoom.java
@@ -1,0 +1,45 @@
+package com.runto.domain.chat.domain;
+
+import com.runto.domain.common.BaseTimeEntity;
+import com.runto.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+@Table(name = "direct_chat_room", uniqueConstraints =
+        {@UniqueConstraint(columnNames = {"user1_id","user2_id"})})
+public class DirectChatRoom extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "direct_chat_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user1_id", nullable = false)
+    private User user1;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user2_id", nullable = false)
+    private User user2;
+
+    //채팅방의 상태? -> 그룹채팅도 마찬가지로 넣을지 말지 생각하기
+
+    //Optimistic Lock -> 읽기의 비율이 높음
+    @Version
+    private Long version;
+
+    public static DirectChatRoom createRoom(User user1, User user2){
+        DirectChatRoom directChatRoom = new DirectChatRoom();
+        directChatRoom.user1 = user1;
+        directChatRoom.user2 = user2;
+        return  directChatRoom;
+    }
+}

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -10,7 +10,6 @@ import static org.springframework.http.HttpStatus.*;
 @AllArgsConstructor
 public enum ErrorCode {
 
-
     USER_NOT_FOUND(NOT_FOUND,"존재하지 않는 유저입니다." ),
     USER_INACTIVE(FORBIDDEN,"사용자가 비활성 상태입니다. 이 작업을 수행할 수 없습니다."),
 
@@ -23,6 +22,7 @@ public enum ErrorCode {
     CHATROOM_ALREADY_JOINED(BAD_REQUEST,"이미 참여중인 채팅방입니다."),
     CHATROOM_FULL(BAD_REQUEST,"채팅방이 최대 인원수에 도달했습니다."),
     ALREADY_EXIST_USER(CONFLICT,"이미 존재하는 사용자입니다."),
+    CHATROOM_CREATE_FAILED(INTERNAL_SERVER_ERROR,"채팅방 생성중 오류가 발생했습니다."),
 
 
     // 이미지 관련

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     CHATROOM_ALREADY_JOINED(BAD_REQUEST,"이미 참여중인 채팅방입니다."),
     CHATROOM_FULL(BAD_REQUEST,"채팅방이 최대 인원수에 도달했습니다."),
     ALREADY_EXIST_USER(CONFLICT,"이미 존재하는 사용자입니다."),
-    CHATROOM_CREATE_FAILED(INTERNAL_SERVER_ERROR,"채팅방 생성중 오류가 발생했습니다."),
+    CHATROOM_CREATE_FAILED_OWN(INTERNAL_SERVER_ERROR,"나 자신과의 채팅방을 만들 수 없습니다."),
 
 
     // 이미지 관련

--- a/src/main/java/com/runto/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/runto/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.runto.global.exception;
 
+import com.runto.domain.chat.exception.ChatException;
 import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.image.exception.ImageException;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ImageException.class)
     public ResponseEntity<ErrorResult> handleImageException(ImageException e) {
         log.error("[ImageException] ex", e);
+        return makeErrorResult(e.getErrorCode());
+    }
+
+    @ExceptionHandler(ChatException.class)
+    public ResponseEntity<ErrorResult> handleChatException(ChatException e) {
         return makeErrorResult(e.getErrorCode());
     }
 


### PR DESCRIPTION


## 🔎 작업 내용

- ChatException 에러 처리 추가
- ErrorCode에 채팅방 생성시 서버 에러 추가
- DirectChatRoom 엔티티 구현
- DirectChatController 컨트롤러에 1:1채팅방 생성 api 구현
- exitsByUserPair : 유저 쌍이 존재하는지 여부 확인 쿼리문 구현
- 1:1채팅방 생성 서비스 로직 구현


  <br/>

## 이미지 첨부 (선)


<br/>

## 🔧 리뷰 요구사항

<br/>
closes #10 
