### PR TITLE
✨ Feat(#33): 내 모임목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,17 @@ dependencies {
 
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    //Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //Querydsl,  자동 생성된 Q클래스 gradle clean으로 제거
+    clean {
+        delete file('src/main/generated')
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/runto/domain/common/SortUtil.java
+++ b/src/main/java/com/runto/domain/common/SortUtil.java
@@ -1,0 +1,48 @@
+package com.runto.domain.common;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+public class SortUtil {
+
+    /**
+     *
+     * @param entityClass: 엔티티타입
+     * @param fieldName: 정렬 기준이 될 필드이름
+     * @param direction: 정렬 방식
+     * @return OrderSpecifier<?>
+     */
+    public static <T> OrderSpecifier<?> getOrderSpecifier(Class<T> entityClass,
+                                                          String fieldName,
+                                                          Sort.Direction direction) {
+        // 엔티티의 PathBuilder 생성
+        PathBuilder<T> entityPath = new PathBuilder<>(entityClass, entityClass.getSimpleName().toLowerCase());
+
+        // 정렬 순서 지정
+        Order order = direction.isAscending() ? Order.ASC : Order.DESC;
+
+        // 필드 이름과 정렬 순서를 사용하여 OrderSpecifier 생성
+        return new OrderSpecifier(order, entityPath.get(fieldName));
+    }
+
+
+    // 구현했던 여러 버전 중에서 사용했던 메서드 중 하나인데, 나중에 혹시 쓸 수도 있으니 일단 남겨둡니다.
+//    public static Sort.Direction getFirstDirectionFromPageable(Pageable pageable) {
+//        return pageable.getSort()
+//                .stream()
+//                .findFirst()                 // 첫 번째 정렬 조건 가져오기
+//                .map(Sort.Order::getDirection) // Direction 값 추출
+//                .orElse(Sort.Direction.DESC);  // 기본값 설정 (필요 시 변경 가능)
+//    }
+//    public static List<Sort.Direction> getAllDirectionFromPageable(Pageable pageable) {
+//        return pageable.getSort()
+//                .stream()// 첫 번째 정렬 조건 가져오기
+//                .map(order -> order.getDirection() == null ? Sort.Direction.DESC : order.getDirection()) // Direction 값 추출
+//                .toList();  // 기본값 설정 (필요 시 변경 가능)
+//    }
+}

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -3,11 +3,17 @@ package com.runto.domain.gathering.api;
 import com.runto.domain.gathering.application.GatheringService;
 import com.runto.domain.gathering.dto.CreateGatheringRequest;
 import com.runto.domain.gathering.dto.GatheringDetailResponse;
+import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
+import com.runto.domain.gathering.dto.UserGatheringsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/gatherings")
@@ -27,6 +33,19 @@ public class GatheringController {
     public ResponseEntity<GatheringDetailResponse> getGatheringDetail(
             @PathVariable("gathering_id") Long gatheringId) {
         return ResponseEntity.ok(gatheringService.getGatheringDetail(gatheringId));
+    }
+
+
+    // TODO userId -> userDetails 로 바꿔야함
+    @GetMapping
+    public ResponseEntity<UserGatheringsResponse> getMyGatherings(
+            @RequestParam(name = "user_id") Long userId, // before 유저인증 적용
+            @PageableDefault(size = 8) Pageable pageable,
+            @Valid @ModelAttribute UserGatheringsRequestParams requestParams
+    ) {
+
+        return ResponseEntity.ok(gatheringService
+                .getUserGatherings(userId, pageable, requestParams));
     }
 
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -5,6 +5,8 @@ import com.runto.domain.gathering.dao.GatheringRepository;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.dto.CreateGatheringRequest;
 import com.runto.domain.gathering.dto.GatheringDetailResponse;
+import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
+import com.runto.domain.gathering.dto.UserGatheringsResponse;
 import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.image.application.ImageService;
 import com.runto.domain.image.domain.GatheringImage;
@@ -14,6 +16,7 @@ import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,7 +61,7 @@ public class GatheringService {
 //        imageService.moveImageFromTempToPermanent(request.getGatheringImageUrls()
 //                .getContentImageUrls());
     }
-    
+
     // TODO: 설정 날짜 관련 서비스 정책? 정하고 구현
     private void validateDate(LocalDateTime deadLine, LocalDateTime appointedAt) {
         return;
@@ -79,5 +82,15 @@ public class GatheringService {
                 .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
 
         return GatheringDetailResponse.from(gathering);
+    }
+
+
+    // 내 모임목록조회에만 사용되지 않고 특정유저의 모임목록을 조회할 수 있는 상황을 고려하였음
+    public UserGatheringsResponse getUserGatherings(Long userId,
+                                                    Pageable pageable,
+                                                    UserGatheringsRequestParams requestParams) {
+
+        return UserGatheringsResponse.fromGatherings(
+                gatheringRepository.getUserGatherings(userId, pageable, requestParams));
     }
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface GatheringRepository extends JpaRepository<Gathering, Long> {
+public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringRepositoryCustom {
 
     @Query("select g from Gathering g " +
             " join fetch g.gatheringMembers gm " +

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.runto.domain.gathering.dao;
+
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GatheringRepositoryCustom {
+
+    Slice<Gathering> getUserGatherings(Long userId,
+                                       Pageable pageable,
+                                       UserGatheringsRequestParams requestParams);
+}

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -1,0 +1,121 @@
+package com.runto.domain.gathering.dao;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
+import com.runto.domain.gathering.type.GatheringMemberRole;
+import com.runto.domain.gathering.type.GatheringOrderField;
+import com.runto.domain.gathering.type.GatheringTimeStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.runto.domain.common.SortUtil.getOrderSpecifier;
+import static com.runto.domain.gathering.domain.QGathering.gathering;
+import static com.runto.domain.gathering.dto.QGatheringMember.gatheringMember;
+import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
+import static com.runto.domain.gathering.type.GatheringTimeStatus.ENDED;
+import static com.runto.domain.gathering.type.GatheringTimeStatus.ONGOING;
+
+@RequiredArgsConstructor
+@Repository
+public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public Slice<Gathering> getUserGatherings(Long userId,
+                                              Pageable pageable,
+                                              UserGatheringsRequestParams request) {
+
+        List<Gathering> gatherings = jpaQueryFactory.selectFrom(gathering)
+                .join(gathering.gatheringMembers).fetchJoin()
+                .where(
+                        memberRoleCondition(userId, request.getMemberRole()),
+                        timeCondition(request.getGatheringTimeStatus()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1) // 다음 페이지에 가져올 컨텐츠가 있는지 확인하기 위함
+                .orderBy(orderCondition(request.getOrderBy(), request.getSortDirection()))
+                .fetch();
+
+        return new SliceImpl<>(gatherings, pageable, hasNextPage(pageable, gatherings));
+    }
+
+    private boolean hasNextPage(Pageable pageable, List<Gathering> gatherings) {
+        boolean hasNext = false;
+        if (gatherings.size() > pageable.getPageSize()) {
+            hasNext = true;
+            gatherings.remove(gatherings.size() - 1); // 확인용으로 가져왔던 컨텐츠는 삭제
+        }
+        return hasNext;
+    }
+
+
+    // TODO 출석체크 api 구현 후 조건 추가될 수도 있음
+    private BooleanExpression timeCondition(GatheringTimeStatus gatheringTimeStatus) {
+
+        // 약속모임날짜시간이 지나지 않은 모임만 노출
+        if (ONGOING.equals(gatheringTimeStatus)) {
+            return gathering.appointedAt.after(LocalDateTime.now());
+        }
+        // 약속모임날짜시간이 지난 모임만 노출
+        if (ENDED.equals(gatheringTimeStatus)) {
+            return gathering.appointedAt.before(LocalDateTime.now());
+        }
+
+        // 전체 노출
+        return null;
+    }
+
+    private BooleanExpression memberRoleCondition(Long userId, GatheringMemberRole memberRole) {
+
+        // 회원이 주최자인 모임
+        if (ORGANIZER.equals(memberRole)) {
+            return gathering.organizerId.eq(userId);
+        }
+
+        // 회원이 참가자인 모임
+        return gathering.id.in(
+                JPAExpressions.select(gathering.id)
+                        .from(gatheringMember)
+                        .where(gatheringMember.user.id.eq(userId)));
+    }
+
+
+
+    // PathBuilder 동적 표현식 활용 (이유는 pr에 작성)
+    private OrderSpecifier<?> orderCondition(GatheringOrderField gatheringOrderField,
+                                             Sort.Direction direction) {
+
+        return getOrderSpecifier(Gathering.class,
+                gatheringOrderField.getName(), direction);
+    }
+
+
+    // 이젠 사용하지 않는 메서드지만 위의 방식과 비교하시기 편하라고 남겨둡니다.
+//    private OrderSpecifier<?> orderConditionDepreciate(GatheringOrder order) {
+//
+//        // 약속기한 임박순
+//        if (APPOINTMENT_ASC.equals(order)) {
+//            return gathering.appointedAt.asc();
+//        }
+//
+//        // 모임생성 최신순
+//        if (CREATED_DATE_DESC.equals(order)) {
+//            return gathering.createdAt.desc();
+//        }
+//
+//        // 디폴트 조건 (프론트과 논의 후 변경될 수 있음)
+//        return gathering.appointedAt.asc();
+//    }
+}

--- a/src/main/java/com/runto/domain/gathering/domain/Gathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Gathering.java
@@ -106,6 +106,7 @@ public class Gathering extends BaseTimeEntity {
         });
     }
 
+    // TODO: 참가 구현시 동시성 적용
     public void addMember(User user, GatheringMemberRole role) {
         if (!UserStatus.ACTIVE.equals(user.getStatus())) {
             throw new GatheringException(USER_INACTIVE);

--- a/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
@@ -1,0 +1,45 @@
+package com.runto.domain.gathering.dto;
+
+import com.runto.domain.gathering.type.GatheringMemberRole;
+import com.runto.domain.gathering.type.GatheringOrderField;
+import com.runto.domain.gathering.type.GatheringTimeStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+// 참고: @ModelAttribute는 요청 데이터 바인딩 과정에서 ObjectMapper를 사용하지 않음 -> setter 필요, @JsonNaming 미작동
+@NoArgsConstructor
+@Getter
+public class UserGatheringsRequestParams { // Query Parameter 로 매핑 (ModelAttribute 적용)
+
+    @NotNull(message = "member_role 은 필수 값입니다.")
+    private GatheringMemberRole memberRole;
+
+    private GatheringTimeStatus gatheringTimeStatus;
+
+    @NotNull(message = "order_field 는 필수 값입니다.")
+    private GatheringOrderField orderBy;
+
+    @NotNull(message = "sort_direction 은 필수 값입니다.")
+    private Sort.Direction sortDirection;
+
+
+    // TODO: ModelAttribute를  적용하는 곳이 많아지면 별도의 필터를 구현할 것을 고려
+    // snake case를 처리할 수 있는 별도의 Setter 선언
+    public void setMember_role(@NotNull GatheringMemberRole memberRole) {
+        this.memberRole = memberRole;
+    }
+
+    public void setGathering_time_status(GatheringTimeStatus gatheringTimeStatus) {
+        this.gatheringTimeStatus = gatheringTimeStatus;
+    }
+
+    public void setOrder_by(@NotNull GatheringOrderField orderBy) {
+        this.orderBy = orderBy;
+    }
+
+    public void setSort_direction(Sort.@NotNull Direction sortDirection) {
+        this.sortDirection = sortDirection;
+    }
+}

--- a/src/main/java/com/runto/domain/gathering/dto/UserGatheringsResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserGatheringsResponse.java
@@ -1,0 +1,29 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.type.GatheringResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserGatheringsResponse {
+
+    private Slice<GatheringResponse> userGatheringResponses;
+
+    public static UserGatheringsResponse fromGatherings(Slice<Gathering> gatherings) {
+
+        return UserGatheringsResponse.builder()
+                .userGatheringResponses(gatherings.map(GatheringResponse::from))
+                .build();
+    }
+
+}

--- a/src/main/java/com/runto/domain/gathering/type/GatheringMemberRole.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringMemberRole.java
@@ -1,7 +1,14 @@
 package com.runto.domain.gathering.type;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum GatheringMemberRole {
 
-    ORGANIZER, // 주최자
-    PARTICIPANT // 참여자
+    ORGANIZER("주최자"),
+    PARTICIPANT("참여자");
+
+    private final String description;
 }

--- a/src/main/java/com/runto/domain/gathering/type/GatheringOrderField.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringOrderField.java
@@ -1,0 +1,20 @@
+package com.runto.domain.gathering.type;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum GatheringOrderField { // 일반목록조회, 내 모임 조회 둘 다 사용할 예정
+
+    APPOINTED_AT("모임약속날", "appointedAt"),
+    DEADLINE("신청 마감", "deadline"),
+    HITS("조회수","hits"),
+    CREATED_AT("생성일", "createdAt");
+
+    private final String description;
+    private final String name;
+
+}

--- a/src/main/java/com/runto/domain/gathering/type/GatheringResponse.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringResponse.java
@@ -1,0 +1,64 @@
+package com.runto.domain.gathering.type;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.dto.GatheringMember;
+import com.runto.domain.gathering.dto.LocationDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
+
+    private Long id;
+    private Long organizerId;
+    private String title;
+    private LocalDateTime appointedAt;
+    private LocalDateTime deadline;
+    private RunningConcept concept;
+    private GoalDistance goalDistance;
+    private String thumbnailUrl;
+    private Long hits;
+    private LocationDto location;
+    private GatheringStatus status;
+    private Integer maxNumber;
+    private Integer currentNumber;
+
+    private List<String> memberProfileUrls;
+
+    public static GatheringResponse from(Gathering gathering) {
+
+        List<String> memberProfileUrls = gathering.getGatheringMembers().stream()
+                .map(member -> member.getUser().getProfileImageUrl())
+                .toList();
+
+        return GatheringResponse.builder()
+                .id(gathering.getId())
+                .organizerId(gathering.getOrganizerId())
+                .title(gathering.getTitle())
+                .appointedAt(gathering.getAppointedAt())
+                .deadline(gathering.getDeadline())
+                .concept(gathering.getConcept())
+                .goalDistance(gathering.getGoalDistance())
+                .thumbnailUrl(gathering.getThumbnailUrl())
+                .hits(gathering.getHits())
+                .location(LocationDto.from(gathering.getLocation()))
+                .status(gathering.getStatus())
+                .maxNumber(gathering.getMaxNumber())
+                .currentNumber(gathering.getCurrentNumber())
+                .memberProfileUrls(memberProfileUrls)
+                .build();
+    }
+}

--- a/src/main/java/com/runto/domain/gathering/type/GatheringTimeStatus.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringTimeStatus.java
@@ -1,0 +1,16 @@
+package com.runto.domain.gathering.type;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum GatheringTimeStatus { // 일반목록조회, 내 모임 조회 둘 다 사용할 예정
+
+    UPCOMING("신청기한이 지나지 않은 모임"),
+    ENDED("종료된 모임"),
+    ONGOING("종료되지 않은 모임");
+
+    private final String description;
+
+}

--- a/src/main/java/com/runto/global/config/PageableConfig.java
+++ b/src/main/java/com/runto/global/config/PageableConfig.java
@@ -1,0 +1,20 @@
+package com.runto.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
+
+@Configuration
+public class PageableConfig { // yml에서도 설정가능하긴한데, Pageable 처리에 대한 공부를 위해 빈 등록방식으로 했습니다.
+
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer customize() {
+
+        // void customize(PageableHandlerMethodArgumentResolver pageableResolver);
+        return pageableResolver -> {
+            pageableResolver.setOneIndexedParameters(true);
+            pageableResolver.setMaxPageSize(20);
+        };
+
+    }
+}

--- a/src/main/java/com/runto/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/runto/global/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.runto.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDSLConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/runto/test_api/TestDataInit.java
+++ b/src/main/java/com/runto/test_api/TestDataInit.java
@@ -1,5 +1,10 @@
 package com.runto.test_api;
 
+import com.runto.domain.gathering.dao.GatheringRepository;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.domain.Location;
+import com.runto.domain.gathering.type.GoalDistance;
+import com.runto.domain.gathering.type.RunningConcept;
 import com.runto.domain.user.dao.LocalAccountRepository;
 import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.LocalAccount;
@@ -11,6 +16,12 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
+import static com.runto.domain.gathering.type.GatheringMemberRole.PARTICIPANT;
 import static com.runto.domain.user.type.Gender.WOMAN;
 
 @RequiredArgsConstructor
@@ -20,26 +31,99 @@ public class TestDataInit {
     private final UserRepository userRepository;
     private final LocalAccountRepository localAccountRepository;
 
+    private final GatheringRepository gatheringRepository;
+
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void init() {
 
+        List<User> users = new ArrayList<>();
 
-        LocalAccount localAccount = LocalAccount.builder()
-                .password("123456")
-                .build();
-        User user = User.builder()
-                .email("runto@gmail.com")
-                .name("임시유저")
-                .nickname("임시유저")
-                .gender(WOMAN)
-                //.status()
-                .localAccount(localAccount)
-                .role(UserRole.USER)
-                //.profileImageUrl()
-                .build();
+        for (int i = 0; i < 10; i++) {
+            LocalAccount localAccount = LocalAccount.builder()
+                    .password("123456")
+                    .build();
 
-        userRepository.save(user);
-        localAccountRepository.save(localAccount);
+            users.add(User.builder()
+                    .email("runto@gmail.com")
+                    .name("테스트유저이름" + i + 1)
+                    .nickname("테스트유저닉네임" + i + 1)
+                    .gender(WOMAN)
+                    //.status()
+                    .localAccount(localAccount)
+                    .role(UserRole.USER)
+                    .profileImageUrl(i + 1 + "번유저 썸네일 url")
+                    .build());
+        }
+        users = userRepository.saveAll(users);
+
+
+        List<Gathering> gatherings = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            Gathering gathering = Gathering.builder()
+                    .organizerId(users.get(i).getId())
+                    .title("(기한 남음) 우리 모두 달립시다 " + i)
+                    .description("재밌게 달려봅시다." + i)
+                    .appointedAt(LocalDateTime.now().plusDays(i + 2))
+                    .deadline(LocalDateTime.now().plusDays(i + 1))
+                    .concept(RunningConcept.HEALTH)
+                    .goalDistance(GoalDistance.FREE)
+                    .thumbnailUrl(i + "번 모임 썸네일")
+                    //.hits(0)
+                    .location(Location.of("우리집 앞", 0.0, 0.0))
+                    //.status(NORMAL)
+                    .maxNumber(10)
+                    .currentNumber(1)
+                    .build();
+
+            gathering.addMember(users.get(i), ORGANIZER);
+
+            for (int j = 0; j < 10; j++) {
+                if (j == i) continue;
+
+                if ((i % 2 == 0 && j % 2 == 0) || (i % 2 != 0 && j % 2 != 0)) {
+                    gathering.addMember(users.get(j), PARTICIPANT);
+                }
+            }
+
+            gatherings.add(gathering);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            Gathering gathering = Gathering.builder()
+                    .organizerId(users.get(i).getId())
+                    .title("(기한 만료) 우리 모두 달립시다 " + i)
+                    .description("재밌게 달려봅시다." + i)
+                    .appointedAt(LocalDateTime.now().minusDays(i + 2))
+                    .deadline(LocalDateTime.now().minusDays(i + 1))
+                    .concept(RunningConcept.HEALTH)
+                    .goalDistance(GoalDistance.FREE)
+                    .thumbnailUrl(i + "번 모임 썸네일")
+                    //.hits(0)
+                    .location(Location.of("우리집 앞", 0.0, 0.0))
+                    //.status(NORMAL)
+                    .maxNumber(10)
+                    .currentNumber(1)
+                    .build();
+
+            gathering.addMember(users.get(i), ORGANIZER);
+
+            for (int j = 0; j < 10; j++) {
+                if (j == i) continue;
+
+                if ((i % 2 == 0 && j % 2 == 0) || (i % 2 != 0 && j % 2 != 0)) {
+                    gathering.addMember(users.get(j), PARTICIPANT);
+                }
+            }
+
+            gatherings.add(gathering);
+        }
+
+
+
+        gatherings = gatheringRepository.saveAll(gatherings);
+
+
     }
 }

--- a/src/main/java/com/runto/test_api/TestDataInit.java
+++ b/src/main/java/com/runto/test_api/TestDataInit.java
@@ -49,7 +49,7 @@ public class TestDataInit {
                     .build();
 
             users.add(User.builder()
-                    .email("runto@gmail.com")
+                    .email("runto" + i + "@gmail.com")
                     .name("테스트유저이름" + i + 1)
                     .nickname("테스트유저닉네임" + i + 1)
                     .gender(WOMAN)


### PR DESCRIPTION
## 🔎 작업 내용

### 내 모임목록 조회 기능

  ```       
  @RequestParam(name = "user_id") Long userId, // TODO: userDetails 로 변경
  @PageableDefault(size = 8) Pageable pageable,
  @Valid @ModelAttribute UserGatheringsRequestParams requestParams
 ```
```
public class UserGatheringsRequestParams {

    @NotNull(message = "member_role 은 필수 값입니다.")
    private GatheringMemberRole memberRole;

    private GatheringTimeStatus gatheringTimeStatus;

    @NotNull(message = "order_field 는 필수 값입니다.")
    private GatheringOrderField orderBy;

    @NotNull(message = "sort_direction 은 필수 값입니다.")
    private Sort.Direction sortDirection;

    ......
```
해당 값들을 통해 조건에 맞는 ``gathering 들을 slice 로 페이징`` 하여 반환 (for 커서기반 페이지네이션 적용)

### ``GatheringMemberRole`` 메인값
  -  ``ORGANIZER`` 내가 만든 모임목록
  -  ``PARTICIPANT`` 내가 참여한 모임목록
### ``GatheringTimeStatus``
  -  ``ONGOING`` 종료되지 않은 모임
  -  ``null`` 전체 반환
### ``GatheringOrderField`` - e3197ad3  4a06fe29
  -  ex) ``APPOINTED_AT("모임약속날", "appointedAt")``
### ``Sort.Direction``
  -  ``ASC`` 종료되지 않은 모임
  -  ``DESC`` 전체 반환
### ``Pageable`` - bffd7dec
  -  ``page`` 
  -  ``size`` 디폴트값: 8 , max값: 20
  -  ``size, direction`` 사용 X

---
## ``PathBuilder 동적 표현식`` 적용,  ``GatheringOrderField`` 구성방식 이유
e3197ad3   66cbe510  4a06fe29

### ``글이 너무 기니까 궁금하신 분만 읽으세요``

이제껏 조회를 구현할 때,
정렬에 관한 필터링을 적용할때, 특정필드, 정렬방식 두가지의 의미를 동시에 담은 enum 을 만들었었습니다.
ex) ``LATEST`` -> ``createdAt`` or ``id`` 기준으로 ``desc`` 

### 문제점
조건이 많지 않을 때는 큰 불편함을 못 느꼈었는데, 
여러 조건을 적용해야하는 상황이 되면 enum 값을 계속 만들어야하고, 
위와 같이 단순한 조건이면 여러 api에서 적용 가능하겠지만, 
그렇게 하기 힘든 경우들이 있었습니다. 

 결국 enum 클래스를 따로 또 만들거나  -> 이건 정말 아닌 것 같음
    같은 enum 클래스 내에서 사용처를 구분해서 몰아 넣는다
        -  이 경우 같은 엔티티의 필드에 관한 정렬인데도, 
             어떤 api 에서 사용하느냐에 따라 의미가 많이 달라지는 경우들이 있음 (한 곳에 두기가 애매)
특히 이번에는 여러 api에서 사용할 수 있게끔 하려다보니까 기존의 방식은 제약사항이 많았습니다.

그리고
QueryDsl을 적용한 정렬조건 메서드를 만들 때도, 
안에서 enum 값에 따른 조건문이 계속 추가되어야하는 점과, 
재사용하기 힘들고 api 마다 새로 만들어야하는 상황이었습니다.

api마다 상황이 다른 조건문 같은 경우는 재사용을 못한다고 해도, 
같은 엔티티에 관해 정렬하는 메서드를 이렇게 구현한다는게 계속 걸렸습니다.


### 선택
원래 이런식으로 구현했었던 이유는 pageable로 매핑되는 sort Param 으로 받는 방식은 
필드와 정렬방식을 하나의 문자열로 전달하는데, 잘못된 값을 넘겨도 (필드값)  pageable로 매핑되기때문에,
이미 매핑된 pageable에서 sort를 꺼내서 검증하는 로직을 적용하기가 번거로운 부분이 있다고 생각해서였습니다.
그래서 유연성은 떨어지더라도 안정성있게 구현하자 라는 생각이었습니다.

하지만 위의 문제점에 막히면서 이것저것 생각해보고 시도했었습니다.

이 때 선택한 방식은 PathBuilder 동적 표현식이었고
(다른 엔티티에 관해서도 적용이 가능한 구조로 만들어서 유틸 클래스로 제공했습니다.)

하지만 이것 역시 필드값을 문자열로 받아야해서 안정성이 떨어졌기때문에, 

고민 끝에 하나의 엔티티에 관해 정렬을 적용할 수 있는 필드들에 대한 enum 클래스를 만들어서 받게 끔 했습니다.

```
public enum GatheringOrderField { // 일반목록조회, 내 모임 조회 둘 다 사용할 예정

    APPOINTED_AT("모임약속날", "appointedAt"),
    DEADLINE("신청 마감", "deadline"),
    HITS("조회수","hits"),
    CREATED_AT("생성일", "createdAt");

    private final String description;
    private final String name;

}
```
GatheringOrderField  의 name 값을 동적 쿼리에 넘겨주는 방식으로 하였습니다.

프론트에서는 상황에 따라 필드값, 정렬 값을 조합해서 보낼 수 있고  ``유연성``
pageable 의 sort 로 받는 방식보다는 안전하게 받을 수 있게 끔 했습니다.

  <br/>

## 🔧 리뷰 요구사항
> 여러 사항 고려, 착각한 부분 등으로 인한 삽질로 생각보다 시간이 너무 많이 걸렸네요. (특히 쿼리문이랑, 페이징 설정부분에서..)

> 여러 버전으로 만들었다가 마지막으로 선택한 것만 커밋했습니다.

> enum 이나 정렬조건에 관한 메서드는 해당 api에만 사용하는게 아닌 재사용하는 것을 제 부족한 머리로 최대한 고려하면서 구현해봤습니다.
<br/>

closed: #34 