### PR TITLE
✨Feature(#57): 내 이벤트 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -1,10 +1,7 @@
 package com.runto.domain.gathering.api;
 
 import com.runto.domain.gathering.application.GatheringService;
-import com.runto.domain.gathering.dto.CreateGatheringRequest;
-import com.runto.domain.gathering.dto.GatheringDetailResponse;
-import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
-import com.runto.domain.gathering.dto.UserGatheringsResponse;
+import com.runto.domain.gathering.dto.*;
 import com.runto.global.security.detail.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +30,7 @@ public class GatheringController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/event")
+    @PostMapping("/events")
     public ResponseEntity<Void> requestEventGatheringHosting(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody CreateGatheringRequest request) {
@@ -57,8 +54,7 @@ public class GatheringController {
     public ResponseEntity<UserGatheringsResponse> getMyGatherings(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 8) Pageable pageable,
-            @Valid @ModelAttribute UserGatheringsRequestParams requestParams
-    ) {
+            @Valid @ModelAttribute UserGatheringsRequestParams requestParams) {
 
         return ResponseEntity.ok(gatheringService
                 .getUserGatherings(userDetails.getUserId(), pageable, requestParams));

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -58,4 +58,12 @@ public class GatheringController {
                 .getUserGatherings(userDetails.getUserId(), pageable, requestParams));
     }
 
+    @GetMapping("/events")
+    public ResponseEntity<UserEventGatheringsResponse> getMyEventRequests(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(size = 8) Pageable pageable) {
+
+        return ResponseEntity.ok(gatheringService
+                .getUserEventRequests(userDetails.getUserId(), pageable));
+    }
 }

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -48,8 +48,6 @@ public class GatheringController {
     }
 
 
-    // TODO: 목록 조회시엔 DELETED 외에는 모두 노출 (대신 상세보기는 막는걸로)
-    // TODO: Gathering 에 type 필드 추가로 인해, 필터링 값 추가, 쿼리문 조건 추가 필요
     @GetMapping
     public ResponseEntity<UserGatheringsResponse> getMyGatherings(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -92,7 +92,12 @@ public class GatheringService {
                                                     Pageable pageable,
                                                     UserGatheringsRequestParams requestParams) {
 
-        return UserGatheringsResponse.fromGatherings(
+        if(EVENT.equals(requestParams.getGatheringType())){
+            return UserGatheringsResponse.fromEventGatherings(
+                    gatheringRepository.getUserGatherings(userId, pageable, requestParams));
+        }
+
+        return UserGatheringsResponse.fromGeneralGatherings(
                 gatheringRepository.getUserGatherings(userId, pageable, requestParams));
     }
 

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -5,10 +5,7 @@ import com.runto.domain.gathering.dao.EventGatheringRepository;
 import com.runto.domain.gathering.dao.GatheringRepository;
 import com.runto.domain.gathering.domain.EventGathering;
 import com.runto.domain.gathering.domain.Gathering;
-import com.runto.domain.gathering.dto.CreateGatheringRequest;
-import com.runto.domain.gathering.dto.GatheringDetailResponse;
-import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
-import com.runto.domain.gathering.dto.UserGatheringsResponse;
+import com.runto.domain.gathering.dto.*;
 import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.gathering.type.GatheringType;
 import com.runto.domain.image.application.ImageService;
@@ -92,7 +89,7 @@ public class GatheringService {
                                                     Pageable pageable,
                                                     UserGatheringsRequestParams requestParams) {
 
-        if(EVENT.equals(requestParams.getGatheringType())){
+        if (EVENT.equals(requestParams.getGatheringType())) {
             return UserGatheringsResponse.fromEventGatherings(
                     gatheringRepository.getUserGatherings(userId, pageable, requestParams));
         }
@@ -145,4 +142,8 @@ public class GatheringService {
         }
     }
 
+    public UserEventGatheringsResponse getUserEventRequests(Long userId, Pageable pageable) {
+        return UserEventGatheringsResponse
+                .from(eventGatheringRepository.findEventGatheringsByUserId(userId, pageable));
+    }
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -91,11 +91,11 @@ public class GatheringService {
 
         if (EVENT.equals(requestParams.getGatheringType())) {
             return UserGatheringsResponse.fromEventGatherings(
-                    gatheringRepository.getUserGatherings(userId, pageable, requestParams));
+                    gatheringRepository.getUserEventGatherings(userId, pageable, requestParams));
         }
 
         return UserGatheringsResponse.fromGeneralGatherings(
-                gatheringRepository.getUserGatherings(userId, pageable, requestParams));
+                gatheringRepository.getUserGeneralGatherings(userId, pageable, requestParams));
     }
 
 

--- a/src/main/java/com/runto/domain/gathering/dao/EventGatheringRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/EventGatheringRepository.java
@@ -1,9 +1,19 @@
 package com.runto.domain.gathering.dao;
 
 import com.runto.domain.gathering.domain.EventGathering;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EventGatheringRepository extends JpaRepository<EventGathering, Long> {
+
+    @Query("select e from EventGathering e " +
+            " join fetch e.gathering g" +
+            " where g.organizerId = :user_id")
+    Slice<EventGathering> findEventGatheringsByUserId(
+            @Param("user_id") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
@@ -9,7 +9,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GatheringRepositoryCustom {
 
-    Slice<Gathering> getUserGatherings(Long userId,
+    Slice<Gathering> getUserGeneralGatherings(Long userId,
+                                              Pageable pageable,
+                                              UserGatheringsRequestParams requestParams);
+
+    Slice<Gathering> getUserEventGatherings(Long userId,
                                        Pageable pageable,
                                        UserGatheringsRequestParams requestParams);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -9,6 +9,7 @@ import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
 import com.runto.domain.gathering.type.GatheringMemberRole;
 import com.runto.domain.gathering.type.GatheringOrderField;
 import com.runto.domain.gathering.type.GatheringTimeStatus;
+import com.runto.domain.gathering.type.GatheringType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -43,7 +44,7 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
                 .where(
                         memberRoleCondition(userId, request.getMemberRole()),
                         timeCondition(request.getGatheringTimeStatus()),
-                        gathering.gatheringType.eq(request.getGatheringType())
+                        gatheringTypeCondition(request.getGatheringType())
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1) // 다음 페이지에 가져올 컨텐츠가 있는지 확인하기 위함
@@ -51,6 +52,16 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
                 .fetch();
 
         return new SliceImpl<>(gatherings, pageable, hasNextPage(pageable, gatherings));
+    }
+
+    private BooleanExpression gatheringTypeCondition(GatheringType type) {
+
+        if (type != null) {
+            return gathering.gatheringType.eq(type);
+        }
+
+        // 상관없이 전체 조회
+        return null;
     }
 
     private boolean hasNextPage(Pageable pageable, List<Gathering> gatherings) {
@@ -92,7 +103,6 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
                         .from(gatheringMember)
                         .where(gatheringMember.user.id.eq(userId)));
     }
-
 
 
     // PathBuilder 동적 표현식 활용 (이유는 pr에 작성)

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -3,11 +3,14 @@ package com.runto.domain.gathering.dao;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.runto.domain.gathering.domain.EventGathering;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
-import com.runto.domain.gathering.type.*;
+import com.runto.domain.gathering.type.GatheringMemberRole;
+import com.runto.domain.gathering.type.GatheringOrderField;
+import com.runto.domain.gathering.type.GatheringTimeStatus;
+import com.runto.domain.gathering.type.GatheringType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,15 +20,19 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.runto.domain.common.SortUtil.getOrderSpecifier;
+import static com.runto.domain.gathering.domain.QEventGathering.eventGathering;
 import static com.runto.domain.gathering.domain.QGathering.gathering;
 import static com.runto.domain.gathering.dto.QGatheringMember.gatheringMember;
+import static com.runto.domain.gathering.type.EventRequestStatus.APPROVED;
 import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
-import static com.runto.domain.gathering.type.GatheringStatus.*;
+import static com.runto.domain.gathering.type.GatheringStatus.DELETED;
 import static com.runto.domain.gathering.type.GatheringTimeStatus.ENDED;
 import static com.runto.domain.gathering.type.GatheringTimeStatus.ONGOING;
-import static com.runto.domain.gathering.type.GatheringType.*;
+import static com.runto.domain.gathering.type.GatheringType.EVENT;
+import static com.runto.domain.gathering.type.GatheringType.GENERAL;
 
 @RequiredArgsConstructor
 @Repository
@@ -35,15 +42,16 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
 
 
     @Override
-    public Slice<Gathering> getUserGatherings(Long userId,
-                                              Pageable pageable,
-                                              UserGatheringsRequestParams request) {
+    public Slice<Gathering> getUserGeneralGatherings(Long userId,
+                                                     Pageable pageable,
+                                                     UserGatheringsRequestParams request) {
 
-        List<Gathering> gatherings = selectFromGathering(request.getGatheringType())
+        List<Gathering> gatherings = jpaQueryFactory.selectFrom(gathering)
+                .join(gathering.gatheringMembers).fetchJoin()
                 .where(
                         memberRoleCondition(userId, request.getMemberRole()),
                         timeCondition(request.getGatheringTimeStatus()),
-                        gatheringTypeCondition(request.getGatheringType()),
+                        gatheringTypeCondition(GENERAL),
                         gathering.status.ne(DELETED)
                 )
                 .offset(pageable.getOffset())
@@ -54,17 +62,31 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
         return new SliceImpl<>(gatherings, pageable, hasNextPage(pageable, gatherings));
     }
 
-    /**
-     * 일반모임 목록조회 - 멤버목록 가져오기
-     * 이벤트모임 목록조회 - 멤버목록 X
-     */
-    private JPAQuery<Gathering> selectFromGathering(GatheringType type) {
+    @Override
+    public Slice<Gathering> getUserEventGatherings(Long userId,
+                                                   Pageable pageable,
+                                                   UserGatheringsRequestParams request) {
 
-        if (EVENT.equals(type)) {
-            return jpaQueryFactory.selectFrom(gathering);
-        }
-        return jpaQueryFactory.selectFrom(gathering)
-                .join(gathering.gatheringMembers).fetchJoin();
+        // OneToOne 단방향이어서 일반모임목록 조회랑 select 대상이 다름
+        List<EventGathering> eventGatherings = jpaQueryFactory.selectFrom(eventGathering)
+                .join(eventGathering.gathering).fetchJoin()
+                .where(
+                        memberRoleCondition(userId, request.getMemberRole()),
+                        timeCondition(request.getGatheringTimeStatus()),
+                        gatheringTypeCondition(EVENT),
+                        gathering.status.ne(DELETED),
+                        eventGathering.status.eq(APPROVED)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1) // 다음 페이지에 가져올 컨텐츠가 있는지 확인하기 위함
+                .orderBy(orderCondition(request.getOrderBy(), request.getSortDirection()))
+                .fetch();
+
+        List<Gathering> gatherings = eventGatherings.stream()
+                .map(EventGathering::getGathering)
+                .collect(Collectors.toList());
+
+        return new SliceImpl<>(gatherings, pageable, hasNextPage(pageable, gatherings));
     }
 
 
@@ -101,6 +123,7 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
         // 전체 노출
         return null;
     }
+
 
     private BooleanExpression memberRoleCondition(Long userId, GatheringMemberRole memberRole) {
 

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -42,7 +42,9 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
                 .join(gathering.gatheringMembers).fetchJoin()
                 .where(
                         memberRoleCondition(userId, request.getMemberRole()),
-                        timeCondition(request.getGatheringTimeStatus()))
+                        timeCondition(request.getGatheringTimeStatus()),
+                        gathering.gatheringType.eq(request.getGatheringType())
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1) // 다음 페이지에 가져올 컨텐츠가 있는지 확인하기 위함
                 .orderBy(orderCondition(request.getOrderBy(), request.getSortDirection()))

--- a/src/main/java/com/runto/domain/gathering/domain/EventGathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/EventGathering.java
@@ -3,12 +3,14 @@ package com.runto.domain.gathering.domain;
 import com.runto.domain.common.BaseTimeEntity;
 import com.runto.domain.gathering.type.EventRequestStatus;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static com.runto.domain.gathering.type.EventRequestStatus.PENDING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 
+@Getter
 @NoArgsConstructor
 @Entity
 public class EventGathering extends BaseTimeEntity {

--- a/src/main/java/com/runto/domain/gathering/dto/EventGatheringResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/EventGatheringResponse.java
@@ -1,0 +1,61 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.domain.EventGathering;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.type.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class EventGatheringResponse {
+
+    private Long id;
+    private Long organizerId;
+    private String title;
+    private LocalDateTime appointedAt;
+    private LocalDateTime deadline;
+    private RunningConcept concept;
+    private GoalDistance goalDistance;
+    private String thumbnailUrl;
+    private Long hits;
+    private LocationDto location;
+    private GatheringStatus status;
+    private Integer maxNumber;
+    private Integer currentNumber;
+    private GatheringType gatheringType;
+
+    private EventRequestStatus requestStatus;
+
+    public static EventGatheringResponse from(EventGathering eventGathering) {
+
+        Gathering gathering = eventGathering.getGathering();
+
+        return EventGatheringResponse.builder()
+                .id(gathering.getId())
+                .organizerId(gathering.getOrganizerId())
+                .title(gathering.getTitle())
+                .appointedAt(gathering.getAppointedAt())
+                .deadline(gathering.getDeadline())
+                .concept(gathering.getConcept())
+                .goalDistance(gathering.getGoalDistance())
+                .thumbnailUrl(gathering.getThumbnailUrl())
+                .hits(gathering.getHits())
+                .location(LocationDto.from(gathering.getLocation()))
+                .status(gathering.getStatus())
+                .maxNumber(gathering.getMaxNumber())
+                .currentNumber(gathering.getCurrentNumber())
+                .gatheringType(gathering.getGatheringType())
+                .requestStatus(eventGathering.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/runto/domain/gathering/dto/UserEventGatheringsResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserEventGatheringsResponse.java
@@ -1,0 +1,28 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.domain.EventGathering;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserEventGatheringsResponse {
+
+    private Slice<EventGatheringResponse> userGatheringResponses;
+
+    public static UserEventGatheringsResponse from(Slice<EventGathering> eventGatherings) {
+
+        return UserEventGatheringsResponse.builder()
+                .userGatheringResponses(eventGatherings.map(EventGatheringResponse::from))
+                .build();
+    }
+
+}

--- a/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
@@ -3,6 +3,7 @@ package com.runto.domain.gathering.dto;
 import com.runto.domain.gathering.type.GatheringMemberRole;
 import com.runto.domain.gathering.type.GatheringOrderField;
 import com.runto.domain.gathering.type.GatheringTimeStatus;
+import com.runto.domain.gathering.type.GatheringType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,9 @@ public class UserGatheringsRequestParams { // Query Parameter 로 매핑 (ModelA
     @NotNull(message = "sort_direction 은 필수 값입니다.")
     private Sort.Direction sortDirection;
 
+    @NotNull(message = "gathering_type 은 필수 값입니다.")
+    private GatheringType gatheringType;
+
 
     // TODO: ModelAttribute를  적용하는 곳이 많아지면 별도의 필터를 구현할 것을 고려
     // snake case를 처리할 수 있는 별도의 Setter 선언
@@ -41,5 +45,8 @@ public class UserGatheringsRequestParams { // Query Parameter 로 매핑 (ModelA
 
     public void setSort_direction(Sort.@NotNull Direction sortDirection) {
         this.sortDirection = sortDirection;
+    }
+    public void setGathering_type(GatheringType gatheringType) {
+        this.gatheringType = gatheringType;
     }
 }

--- a/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
@@ -25,6 +25,7 @@ public class UserGatheringsRequestParams { // Query Parameter 로 매핑 (ModelA
     @NotNull(message = "sort_direction 은 필수 값입니다.")
     private Sort.Direction sortDirection;
 
+    @NotNull(message = "gathering_type 은 필수 값입니다.")
     private GatheringType gatheringType;
 
 

--- a/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
@@ -25,7 +25,6 @@ public class UserGatheringsRequestParams { // Query Parameter 로 매핑 (ModelA
     @NotNull(message = "sort_direction 은 필수 값입니다.")
     private Sort.Direction sortDirection;
 
-    @NotNull(message = "gathering_type 은 필수 값입니다.")
     private GatheringType gatheringType;
 
 

--- a/src/main/java/com/runto/domain/gathering/dto/UserGatheringsResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserGatheringsResponse.java
@@ -19,10 +19,17 @@ public class UserGatheringsResponse {
 
     private Slice<GatheringResponse> userGatheringResponses;
 
-    public static UserGatheringsResponse fromGatherings(Slice<Gathering> gatherings) {
+    public static UserGatheringsResponse fromGeneralGatherings(Slice<Gathering> gatherings) {
 
         return UserGatheringsResponse.builder()
-                .userGatheringResponses(gatherings.map(GatheringResponse::from))
+                .userGatheringResponses(gatherings.map(GatheringResponse::fromGeneralGathering))
+                .build();
+    }
+
+    public static UserGatheringsResponse fromEventGatherings(Slice<Gathering> gatherings) {
+
+        return UserGatheringsResponse.builder()
+                .userGatheringResponses(gatherings.map(GatheringResponse::fromEventGathering))
                 .build();
     }
 

--- a/src/main/java/com/runto/domain/gathering/type/GatheringResponse.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringResponse.java
@@ -35,6 +35,7 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
     private GatheringStatus status;
     private Integer maxNumber;
     private Integer currentNumber;
+    private GatheringType gatheringType;
 
     private List<String> memberProfileUrls;
 
@@ -59,6 +60,7 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
                 .maxNumber(gathering.getMaxNumber())
                 .currentNumber(gathering.getCurrentNumber())
                 .memberProfileUrls(memberProfileUrls)
+                .gatheringType(gathering.getGatheringType())
                 .build();
     }
 }

--- a/src/main/java/com/runto/domain/gathering/type/GatheringResponse.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringResponse.java
@@ -3,7 +3,6 @@ package com.runto.domain.gathering.type;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.gathering.domain.Gathering;
-import com.runto.domain.gathering.dto.GatheringMember;
 import com.runto.domain.gathering.dto.LocationDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,9 +36,10 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
     private Integer currentNumber;
     private GatheringType gatheringType;
 
+    // 이벤트모임 조회시엔 null 값으로 내보냄
     private List<String> memberProfileUrls;
 
-    public static GatheringResponse from(Gathering gathering) {
+    public static GatheringResponse fromGeneralGathering(Gathering gathering) {
 
         List<String> memberProfileUrls = gathering.getGatheringMembers().stream()
                 .map(member -> member.getUser().getProfileImageUrl())
@@ -60,6 +60,26 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
                 .maxNumber(gathering.getMaxNumber())
                 .currentNumber(gathering.getCurrentNumber())
                 .memberProfileUrls(memberProfileUrls)
+                .gatheringType(gathering.getGatheringType())
+                .build();
+    }
+
+    public static GatheringResponse fromEventGathering(Gathering gathering) {
+
+        return GatheringResponse.builder()
+                .id(gathering.getId())
+                .organizerId(gathering.getOrganizerId())
+                .title(gathering.getTitle())
+                .appointedAt(gathering.getAppointedAt())
+                .deadline(gathering.getDeadline())
+                .concept(gathering.getConcept())
+                .goalDistance(gathering.getGoalDistance())
+                .thumbnailUrl(gathering.getThumbnailUrl())
+                .hits(gathering.getHits())
+                .location(LocationDto.from(gathering.getLocation()))
+                .status(gathering.getStatus())
+                .maxNumber(gathering.getMaxNumber())
+                .currentNumber(gathering.getCurrentNumber())
                 .gatheringType(gathering.getGatheringType())
                 .build();
     }

--- a/src/main/java/com/runto/test_api/TestDataInit.java
+++ b/src/main/java/com/runto/test_api/TestDataInit.java
@@ -111,7 +111,7 @@ public class TestDataInit {
                     //.status(NORMAL)
                     .maxNumber(10)
                     .currentNumber(1)
-                    .gatheringType(GatheringType.GENERAL)
+                    .gatheringType(GatheringType.EVENT)
                     .build();
 
             gathering.addMember(users.get(i), ORGANIZER);


### PR DESCRIPTION
## 🔎 작업 내용

### 내가 속한 이벤트 목록 조회

![image](https://github.com/user-attachments/assets/f2a262e0-2385-4519-a456-d3e73f2d5945)

이렇게 연관관계를 맺게되면서, 
기존에 구현했던  ``내 모임목록 조회`` (일반모임만 조회하는게 목적)  에서 이벤트모임도 조회되는 상황이 되면서
type 필터링을 적용했어야했습니다.

리팩토링을 하다보니 ``내가 속한 이벤트모임 목록 조회`` 가 
 #34     와 거의 중복되는 부분이라, 해당 코드를 리팩토링하여  두 api 모두 사용할 수 있는 방식을 택했습니다.

**차이점**
``내가 속한 일반모임 목록 조회`` 모임에 속한 멤버를 패치조인해서 가져온다.
``내가 속한 이벤트 목록 조회``  멤버 패치조인 없이 가져온다.

일반 모임의 경우 최대인원이 10명이어서 같이 패치조인해서 가져온뒤 dto에 멤버들의 프로필url을 넣어줬지만
이벤트의 경우 규모가 달라서 가져오지 않게끔 했습니다.


### 수정사항  9cc9903a

---

### 내가 신청한 이벤트 목록 조회

```
    @Query("select e from EventGathering e " +
            " join fetch e.gathering g" +
            " where g.organizerId = :user_id")
    Slice<EventGathering> findEventGatheringsByUserId(
            @Param("user_id") Long userId, Pageable pageable);
```
이렇게 가져온 데이터를 dto에 넣어 반환해줬습니다.
내 모임 목록 조회 반환값과 거의 유사하나, 이벤트신청상태 값이 추가되었습니다.
```
public enum EventRequestStatus {

    PENDING,      // 대기
    APPROVED,     // 승인
    REJECTED      // 승인거부
}
```

  <br/>
closed: #57 