### PR TITLE
✨Feat(#62): 내 런닝캘린더 조회 기능 구현

### DIFF
--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -3,7 +3,6 @@ package com.runto.domain.gathering.application;
 
 import com.runto.domain.gathering.dao.EventGatheringRepository;
 import com.runto.domain.gathering.dao.GatheringRepository;
-import com.runto.domain.gathering.domain.EventGathering;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.dto.*;
 import com.runto.domain.gathering.exception.GatheringException;
@@ -50,11 +49,52 @@ public class GatheringService {
     public void createGatheringGeneral(Long userId, CreateGatheringRequest request) {
 
         validateMaxNumber(request.getGatheringType(), request.getMaxNumber());
-        createGathering(userId, request);
+        gatheringRepository.save(createGathering(userId, request));
 
         // s3 temp 경로에 있던 이미지파일들을 정식 경로에 옮기기
 //        imageService.moveImageFromTempToPermanent(request.getGatheringImageUrls()
 //                .getContentImageUrls());
+    }
+
+    // TODO moveImageProcess 에러 해결되면 주석 풀기
+    @Transactional
+    public void requestEventGatheringHosting(Long userId,
+                                             CreateGatheringRequest request) {
+
+        validateMaxNumber(request.getGatheringType(), request.getMaxNumber());
+
+        Gathering gathering = createGathering(userId, request);
+        gathering.applyForEvent(); // 해당 모임을 이벤트모임으로 신청
+        gatheringRepository.save(gathering);
+
+        // s3 temp 경로에 있던 이미지파일들을 정식 경로에 옮기기
+//        imageService.moveImageFromTempToPermanent(request.getGatheringImageUrls()
+//                .getContentImageUrls());
+
+    }
+
+    private Gathering createGathering(Long userId, CreateGatheringRequest request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+
+        validateDate(request.getDeadline(), request.getAppointedAt());
+
+        Gathering gathering = request.toEntity(user);
+        gathering.addMember(user, ORGANIZER);
+        addContentImages(request.getImageRegisterResponse(), gathering);
+
+        return gathering;
+    }
+
+    // 커스텀 애노테이션 에러 해결되면 삭제
+    private void validateMaxNumber(GatheringType type, int maxNumber) {
+        if (GENERAL.equals(type) && (maxNumber < 2 || maxNumber > 10)) {
+            throw new GatheringException(GENERAL_MAX_NUMBER);
+        }
+        if (EVENT.equals(type) && (maxNumber < 10 || maxNumber > 300)) {
+            throw new GatheringException(EVENT_MAX_NUMBER);
+        }
     }
 
     // TODO: 설정 날짜 관련 서비스 정책? 정하고 구현
@@ -98,49 +138,6 @@ public class GatheringService {
                 gatheringRepository.getUserGeneralGatherings(userId, pageable, requestParams));
     }
 
-
-    // TODO: 회원관련 기능 dev에 머지되면 param 에 UserDetails 추가 & 교체
-    // TODO moveImageProcess 에러 해결되면 주석 풀기
-    // db를 세번 오가는 상황, 그렇다고 gathering에서 양방향으로 넣기엔 안 어울리는 듯 하다.
-    @Transactional
-    public void requestEventGatheringHosting(Long userId,
-                                             CreateGatheringRequest request) {
-
-        validateMaxNumber(request.getGatheringType(), request.getMaxNumber());
-
-        Gathering gathering = createGathering(userId, request);
-        eventGatheringRepository.save(new EventGathering(gathering));
-
-        // s3 temp 경로에 있던 이미지파일들을 정식 경로에 옮기기
-//        imageService.moveImageFromTempToPermanent(request.getGatheringImageUrls()
-//                .getContentImageUrls());
-
-    }
-
-    private Gathering createGathering(Long userId, CreateGatheringRequest request) {
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
-
-        validateDate(request.getDeadline(), request.getAppointedAt());
-
-        Gathering gathering = request.toEntity(user);
-        gathering.addMember(user, ORGANIZER);
-        addContentImages(request.getImageRegisterResponse(), gathering);
-
-        gatheringRepository.save(gathering);
-        return gathering;
-    }
-
-    // 커스텀 애노테이션 에러 해결되면 삭제
-    private void validateMaxNumber(GatheringType type, int maxNumber) {
-        if (GENERAL.equals(type) && (maxNumber < 2 || maxNumber > 10)) {
-            throw new GatheringException(GENERAL_MAX_NUMBER);
-        }
-        if (EVENT.equals(type) && (maxNumber < 10 || maxNumber > 300)) {
-            throw new GatheringException(EVENT_MAX_NUMBER);
-        }
-    }
 
     public UserEventGatheringsResponse getUserEventRequests(Long userId, Pageable pageable) {
         return UserEventGatheringsResponse

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -13,6 +13,7 @@ import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUrlDto;
 import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.User;
+import com.runto.domain.user.dto.UserCalenderResponse;
 import com.runto.domain.user.excepction.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -142,5 +143,13 @@ public class GatheringService {
     public UserEventGatheringsResponse getUserEventRequests(Long userId, Pageable pageable) {
         return UserEventGatheringsResponse
                 .from(eventGatheringRepository.findEventGatheringsByUserId(userId, pageable));
+    }
+
+    public UserCalenderResponse getUserMonthlyGatherings(Long userId, int year, int month) {
+
+        return UserCalenderResponse
+                .fromGatheringMembers(gatheringRepository
+                        .getUserMonthlyGatherings(userId, year, month));
+
     }
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
@@ -1,10 +1,13 @@
 package com.runto.domain.gathering.dao;
 
 import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.dto.GatheringMember;
 import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface GatheringRepositoryCustom {
@@ -14,6 +17,8 @@ public interface GatheringRepositoryCustom {
                                               UserGatheringsRequestParams requestParams);
 
     Slice<Gathering> getUserEventGatherings(Long userId,
-                                       Pageable pageable,
-                                       UserGatheringsRequestParams requestParams);
+                                            Pageable pageable,
+                                            UserGatheringsRequestParams requestParams);
+
+    List<GatheringMember> getUserMonthlyGatherings(Long userId, int year, int month);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -155,13 +155,21 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
         if (ORGANIZER.equals(memberRole)) {
             return gathering.organizerId.eq(userId);
         }
-
         // 회원이 참가자인 모임
+        if (PARTICIPANT.equals(memberRole)) {
+
+            return gathering.id.in(
+                    JPAExpressions.select(gathering.id)
+                            .from(gatheringMember)
+                            .where(gatheringMember.user.id.eq(userId)
+                                    .and(gatheringMember.role.eq(PARTICIPANT))));
+        }
+
+        // 회원이 해당 모임의 멤버인 경우(주최자, 참가자 상관없이)
         return gathering.id.in(
                 JPAExpressions.select(gathering.id)
                         .from(gatheringMember)
-                        .where(gatheringMember.user.id.eq(userId)
-                                .and(gatheringMember.role.eq(PARTICIPANT))));
+                        .where(gatheringMember.user.id.eq(userId)));
     }
 
     private BooleanExpression yearMonthCondition(int year, int month) {

--- a/src/main/java/com/runto/domain/gathering/domain/EventGathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/EventGathering.java
@@ -19,8 +19,9 @@ public class EventGathering extends BaseTimeEntity {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @JoinColumn(name = "gathering_id")
-    @OneToOne(fetch = FetchType.LAZY)
+    // oneToOne 양방향일 경우 주인이 아닌 쪽을 가져올때, LAZY 가 작동안하지만 EventGathering 를 가져올땐,
+    // 항상 Gathering 을 가져오기해서 join fetch 를 쓸거고, 큰 상관은 없는 듯 하다.
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "eventGathering")
     private Gathering gathering;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/runto/domain/gathering/domain/EventGathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/EventGathering.java
@@ -12,11 +12,13 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Getter
 @NoArgsConstructor
+@Table(name = "event_gathering")
 @Entity
 public class EventGathering extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "event_gathering_id")
     private Long id;
 
     // oneToOne 양방향일 경우 주인이 아닌 쪽을 가져올때, LAZY 가 작동안하지만 EventGathering 를 가져올땐,

--- a/src/main/java/com/runto/domain/gathering/domain/Gathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Gathering.java
@@ -18,8 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.runto.domain.gathering.type.GatheringStatus.NORMAL;
-import static com.runto.global.exception.ErrorCode.IMAGE_SAVE_LIMIT_EXCEEDED;
-import static com.runto.global.exception.ErrorCode.USER_INACTIVE;
+import static com.runto.global.exception.ErrorCode.*;
 import static lombok.AccessLevel.PROTECTED;
 
 @Builder
@@ -81,6 +80,10 @@ public class Gathering extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private GatheringType gatheringType;
 
+    @JoinColumn(name = "event_gathering_id")
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private EventGathering eventGathering;
+
     @Builder.Default
     @OneToMany(mappedBy = "gathering", cascade = CascadeType.ALL)
     private List<GatheringImage> contentImages = new ArrayList<>();
@@ -111,6 +114,14 @@ public class Gathering extends BaseTimeEntity {
             throw new GatheringException(USER_INACTIVE);
         }
         gatheringMembers.add(GatheringMember.of(this, user, role));
+    }
+
+    // 해당 모임을 이벤트모임으로 신청
+    public void applyForEvent() {
+        if (maxNumber < 10 || maxNumber > 300) {
+            throw new GatheringException(EVENT_MAX_NUMBER);
+        }
+        this.eventGathering = new EventGathering(this);
     }
 
 

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
@@ -35,6 +35,9 @@ public class GatheringMember extends BaseTimeEntity {
     @Column(name = "gathering_member_role")
     private GatheringMemberRole role;
 
+    @Column(name = "real_distance")
+    private Double realDistance;
+
     public static GatheringMember of(Gathering gathering, User user, GatheringMemberRole role) {
         return GatheringMember.builder()
                 .gathering(gathering)
@@ -46,6 +49,7 @@ public class GatheringMember extends BaseTimeEntity {
     @PrePersist
     public void prePersist() {
         attendanceStatus = AttendanceStatus.PENDING;
+        realDistance = 0.0;
     }
 
 }

--- a/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
+++ b/src/main/java/com/runto/domain/gathering/dto/UserGatheringsRequestParams.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Sort;
 @Getter
 public class UserGatheringsRequestParams { // Query Parameter 로 매핑 (ModelAttribute 적용)
 
-    @NotNull(message = "member_role 은 필수 값입니다.")
     private GatheringMemberRole memberRole;
 
     private GatheringTimeStatus gatheringTimeStatus;
@@ -46,6 +45,7 @@ public class UserGatheringsRequestParams { // Query Parameter 로 매핑 (ModelA
     public void setSort_direction(Sort.@NotNull Direction sortDirection) {
         this.sortDirection = sortDirection;
     }
+
     public void setGathering_type(GatheringType gatheringType) {
         this.gatheringType = gatheringType;
     }

--- a/src/main/java/com/runto/domain/user/api/UserController.java
+++ b/src/main/java/com/runto/domain/user/api/UserController.java
@@ -1,8 +1,10 @@
 package com.runto.domain.user.api;
 
+import com.runto.domain.gathering.application.GatheringService;
 import com.runto.domain.user.application.UserService;
 import com.runto.domain.user.dto.CheckEmailRequest;
 import com.runto.domain.user.dto.SignupRequest;
+import com.runto.domain.user.dto.UserCalenderResponse;
 import com.runto.global.security.detail.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -18,6 +20,8 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class UserController {
     private final UserService userService;
+    private final GatheringService gatheringService;
+
 
     //model attribute 사용시 setter필요
     @PostMapping("/signup")
@@ -33,9 +37,21 @@ public class UserController {
         userService.checkEmailDuplicate(checkEmailRequest);
         return ResponseEntity.ok().build();
     }
+
     @GetMapping("/my")
     public ResponseEntity<Void> getUser(@AuthenticationPrincipal CustomUserDetails user) {
         System.out.println(user.getUserId());
         return ResponseEntity.ok().build();
+    }
+
+
+    @GetMapping("/calender")
+    public ResponseEntity<UserCalenderResponse> getMyMonthlyGatherings(
+            @RequestParam("year") int year,
+            @RequestParam("month") int month,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return ResponseEntity.ok(gatheringService
+                .getUserMonthlyGatherings(userDetails.getUserId(), year, month));
     }
 }

--- a/src/main/java/com/runto/domain/user/dto/CalendarGatheringResponse.java
+++ b/src/main/java/com/runto/domain/user/dto/CalendarGatheringResponse.java
@@ -1,0 +1,61 @@
+package com.runto.domain.user.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.dto.GatheringMember;
+import com.runto.domain.gathering.type.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+public class CalendarGatheringResponse {
+
+    private Long id;
+    private Long organizerId;
+    private LocalDateTime appointedAt;
+    private LocalDateTime deadline;
+    private RunningConcept concept;
+    private GoalDistance goalDistance;
+    private Integer maxNumber;
+    private Integer currentNumber;
+    private GatheringStatus status;
+    private GatheringType gatheringType;
+
+    // memberId 로 하면 GatheringMember의 pk 값 같아서 헷갈릴 소지가 있기때문에 이렇게 명명하였음
+    private Long memberAccountId;
+    private GatheringMemberRole role;
+    private AttendanceStatus attendanceStatus;
+    private Double realDistance;
+
+
+    public static CalendarGatheringResponse from(GatheringMember member) { // 패치조인해온 gatheringMember
+
+        Gathering gathering = member.getGathering();
+
+        return CalendarGatheringResponse.builder()
+                .id(gathering.getId())
+                .organizerId(gathering.getOrganizerId())
+                .appointedAt(gathering.getAppointedAt())
+                .deadline(gathering.getDeadline())
+                .concept(gathering.getConcept())
+                .goalDistance(gathering.getGoalDistance())
+                .maxNumber(gathering.getMaxNumber())
+                .currentNumber(gathering.getCurrentNumber())
+                .status(gathering.getStatus())
+                .gatheringType(gathering.getGatheringType())
+                .memberAccountId(member.getUser().getId())
+                .role(member.getRole())
+                .attendanceStatus(member.getAttendanceStatus())
+                .realDistance(member.getRealDistance())
+                .build();
+    }
+}

--- a/src/main/java/com/runto/domain/user/dto/UserCalenderResponse.java
+++ b/src/main/java/com/runto/domain/user/dto/UserCalenderResponse.java
@@ -1,0 +1,55 @@
+package com.runto.domain.user.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.dto.GatheringMember;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.runto.domain.gathering.type.AttendanceStatus.ATTENDING;
+import static com.runto.domain.gathering.type.GatheringType.EVENT;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserCalenderResponse {
+
+    private int monthlyGatheringTotalCount;
+    private int attendanceCount;
+    private int eventGatheringCount;
+    private double totalRealDistance;
+
+    private List<CalendarGatheringResponse> gatherings;
+
+
+    public static UserCalenderResponse fromGatheringMembers(List<GatheringMember> gatheringMembers) {
+
+        UserCalenderResponse response = new UserCalenderResponse();
+        response.monthlyGatheringTotalCount = gatheringMembers.size();
+
+        response.gatherings = new ArrayList<>();
+
+        for (GatheringMember gatheringMember : gatheringMembers) {
+            response.gatherings.add(CalendarGatheringResponse.from(gatheringMember));
+
+            response.totalRealDistance += gatheringMember.getRealDistance();
+
+            if (ATTENDING.equals(gatheringMember.getAttendanceStatus())){
+                response.attendanceCount++;
+            }
+
+            if(EVENT.equals(gatheringMember.getGathering().getGatheringType())){
+                response.eventGatheringCount++;
+            }
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/runto/global/config/SecurityConfig.java
+++ b/src/main/java/com/runto/global/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
         http.httpBasic(AbstractHttpConfigurer::disable);
         http.authorizeHttpRequests(auth-> auth
                 .requestMatchers("/**").permitAll()
-                .requestMatchers("images/**", "gatherings/**").authenticated()
+                .requestMatchers("images/**", "gatherings/**", "users/calender/**").authenticated()
                 .anyRequest().authenticated());
 
 

--- a/src/main/java/com/runto/test_api/TestDataInit.java
+++ b/src/main/java/com/runto/test_api/TestDataInit.java
@@ -113,6 +113,7 @@ public class TestDataInit {
                     .currentNumber(1)
                     .gatheringType(GatheringType.EVENT)
                     .build();
+            gathering.applyForEvent();
 
             gathering.addMember(users.get(i), ORGANIZER);
 


### PR DESCRIPTION

## 🔎 작업 내용

### 내 런닝캘린더 조회 기능 
- ``year`` ``month`` 를 입력받아 
로그인상태인 회원 본인의 ``year``년도 ``month``월에 속한 모임들을 반환

-  ``ORGANIZER`` ,  ``PARTICIPANT`` 인지 상관없이 본인이 속한 ``Gathering`` 정보로 응답 (Gathering, EventGathering 모두)
-  ``EventGathering`` 의 경우 승인 상태가 아닌 것은 반환하지 않는다.
-  위의 조건들을 충족하고 삭제상태가 아닌 ``Gathering`` 들을 반환 

- **월 별 활동 데이터**
  -  실제 뛴 거리를 누적  ``totalRealDistance`` 
  -  ``EventGathering`` 의 횟수  ``eventGatheringCount``
  -  모임 출석횟수  ``attendanceCount``
  -  한 달 총 모임횟수(이미 종료된 것, 예정인 것 등 모두 포함) ``monthlyGatheringTotalCount``

  <br/>


## 🔧 리뷰 요구사항

해당 기능을 구현 중 기존의 연관관계로는 제약사항이 많아서 Gathering & EventGathering 연관관계를 수정했습니다.
수정에 따른 기존 기능들의 수정이 이루어졌습니다.

c5287f2a
ffe0c2a0
5354fbc6

<br/>
closed #62 