### PR TITLE
✨ Feat(#52): 1:1 채팅 구현

### DIFF
--- a/.github/workflows/docker-to-ec2.yml
+++ b/.github/workflows/docker-to-ec2.yml
@@ -84,6 +84,19 @@ jobs:
           -e "SERVICE_TOKEN_URL=${{ secrets.SERVICE_TOKEN_URL }}" \
           -e "SERVICE_USER_INFO_URL=${{ secrets.SERVICE_USER_INFO_URL }}" \
           -e "SERVICE_USER_ATTRIBUTE=${{ secrets.SERVICE_USER_ATTRIBUTE }}" \
+          -e "MONGO_DB_URI=${{ secrets.MONGO_DB_URI }}" \
+          -e "RABBIT_HOST=${{ secrets.RABBIT_HOST }}" \
+          -e "RABBIT_USERNAME=${{ secrets.RABBIT_USERNAME }}" \
+          -e "RABBIT_PASSWORD=${{ secrets.RABBIT_PASSWORD }}" \
+          -e "RABBIT_PORT=${{ secrets.RABBIT_PORT }}" \
+          -e "RABBIT_EXCHANGE=${{ secrets.RABBIT_EXCHANGE }}" \
+          -e "RABBIT_DL_EXCHANGE=${{ secrets.RABBIT_DL_EXCHANGE }}" \
+          -e "DEAD_LETTER_QUEUE=${{ secrets.DEAD_LETTER_QUEUE }}" \
+          -e "DEAD_LETTER_ROUTING_KEY=${{ secrets.DEAD_LETTER_ROUTING_KEY }}" \
+          -e "DIRECT_QUEUE_NAME=${{ secrets.DIRECT_QUEUE_NAME }}" \
+          -e "DIRECT_ROUTING_KEY=${{ secrets.DIRECT_ROUTING_KEY }}" \
+          -e "GROUP_QUEUE_NAME=${{ secrets.GROUP_QUEUE_NAME }}" \
+          -e "GROUP_ROUTING_KEY=${{ secrets.GROUP_ROUTING_KEY }}" \
           ${{ secrets.DOCKERHUB_USERNAME }}/runto-cicd:latest
 
       - name: delete old docker image

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,15 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    //WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    //RabbitMQ (amqp)
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    //MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
     //Querydsl,  자동 생성된 Q클래스 gradle clean으로 제거
     clean {
         delete file('src/main/generated')

--- a/src/main/java/com/runto/domain/chat/api/ProducerController.java
+++ b/src/main/java/com/runto/domain/chat/api/ProducerController.java
@@ -1,0 +1,40 @@
+package com.runto.domain.chat.api;
+
+import com.runto.domain.chat.application.ProducerService;
+import com.runto.domain.chat.dto.MessageDTO;
+import com.runto.global.security.detail.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequiredArgsConstructor
+public class ProducerController {
+    private final ProducerService producerService;
+
+    //웹소켓 메시지 전송
+    @MessageMapping("/send/direct")
+    public void sendDirectMessage(@Payload MessageDTO messageDTO,
+                                  @AuthenticationPrincipal CustomUserDetails userDetails){
+        if (messageDTO.getTimestamp() == null){
+            messageDTO.setTimestamp(LocalDateTime.now());
+        }
+        producerService.sendDirectMessage(messageDTO, userDetails.getUserId());
+    }
+
+    //테스트 메시지 전송 api
+    @PostMapping("/send/message")
+    public void sendMessage(@RequestBody MessageDTO messageDTO,
+                            @AuthenticationPrincipal CustomUserDetails userDetails){
+        if (messageDTO.getTimestamp() == null){
+            messageDTO.setTimestamp(LocalDateTime.now());
+        }
+        producerService.sendDirectMessage(messageDTO, userDetails.getUserId());
+    }
+}

--- a/src/main/java/com/runto/domain/chat/application/ConsumerService.java
+++ b/src/main/java/com/runto/domain/chat/application/ConsumerService.java
@@ -1,0 +1,79 @@
+package com.runto.domain.chat.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.runto.domain.chat.dto.MessageQueueDTO;
+import com.runto.domain.chat.dto.MessageResponse;
+import com.runto.domain.chat.exception.ChatException;
+import com.runto.domain.user.dao.UserRepository;
+import com.runto.domain.user.domain.User;
+import com.runto.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.retry.RecoveryCallback;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConsumerService {
+    private final SimpMessagingTemplate simpleMessagingTemplate;
+    private final UserRepository userRepository;
+    private final DirectChatService directChatService;
+    private final RetryTemplate retryTemplate;
+
+    @RabbitListener(queues = "${rabbit.direct.queue}",concurrency = "5")
+    public void receiveDirectMessage(String message){
+        try {
+            log.info("received direct message = {}",message);
+            ObjectMapper objectMapper = new ObjectMapper();
+            MessageQueueDTO messageQueueDTO = objectMapper.readValue(message, MessageQueueDTO.class);
+
+            User user = userRepository.findById(messageQueueDTO.getSenderId())
+                    .orElseThrow(()->new ChatException(ErrorCode.USER_NOT_FOUND));
+
+            MessageResponse messageResponse = MessageResponse.of(messageQueueDTO,user);
+
+            boolean messageSent = retryTemplate.execute(new RetryCallback<Boolean, Exception>() {
+                @Override
+                public Boolean doWithRetry(RetryContext context) throws Exception {
+                    try {
+                        simpleMessagingTemplate.convertAndSend("/topic/direct/" + messageQueueDTO.getRoomId(), messageResponse);
+                        return true;
+                    }catch (MessagingException e){
+                        log.error("Send message Failed = {}",messageResponse,e);
+                        throw e;
+                    }
+                }
+            }, new RecoveryCallback<Boolean>() {
+                @Override
+                public Boolean recover(RetryContext context) throws Exception {
+                    //모든 재시도 실패했을때의 처리
+                    log.error("Send Message to client and retry this. message = {}", messageResponse);
+                    return false;
+                }
+            });
+
+            directChatService.saveDirectChatContent(messageQueueDTO, messageSent);
+
+        }catch (JsonProcessingException e){
+            log.error("Message parsing error to directMessage = {}",e.getMessage());
+
+        }catch (Exception e){
+            log.error("UnExpected error = {}",e.getMessage());
+
+        }
+    }
+    @RabbitListener(queues = "${rabbit.dl.queue}")
+    public void receiveDeadLetterMessage(String message){
+        //데드레터 로그찍기 -> 저장은 나중에 생각해보기
+        log.error("Receive deadLetterMessage in queue = {}",message);
+    }
+
+}

--- a/src/main/java/com/runto/domain/chat/application/DirectChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/DirectChatService.java
@@ -1,9 +1,12 @@
 package com.runto.domain.chat.application;
 
 import com.runto.domain.chat.dao.DirectChatRoomRepository;
+import com.runto.domain.chat.dao.DirectMessageRepository;
+import com.runto.domain.chat.domain.DirectChatContent;
 import com.runto.domain.chat.domain.DirectChatRoom;
 import com.runto.domain.chat.dto.DirectChatInfoDTO;
 import com.runto.domain.chat.dto.DirectChatRoomResponse;
+import com.runto.domain.chat.dto.MessageQueueDTO;
 import com.runto.domain.chat.exception.ChatException;
 import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.User;
@@ -25,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DirectChatService {
     private final UserRepository userRepository;
     private final DirectChatRoomRepository directChatRoomRepository;
+    private final DirectMessageRepository directMessageRepository;
 
     @Transactional
     public DirectChatInfoDTO createAndGetDirectChat(Long userId,Long otherId){
@@ -77,6 +81,15 @@ public class DirectChatService {
         Pageable pageable = PageRequest.of(pageNum,size);
 
         return directChatRoomRepository.getChatRooms(me.getId(), pageable);
+    }
+
+    @Transactional
+    public void saveDirectChatContent(MessageQueueDTO messageQueueDTO, boolean messageSent){
+        DirectChatContent directChatContent = DirectChatContent.of(messageQueueDTO);
+        if (!messageSent){
+            directChatContent.changeStatusToFailed();
+        }
+        directMessageRepository.save(directChatContent);
     }
 
 }

--- a/src/main/java/com/runto/domain/chat/application/ProducerService.java
+++ b/src/main/java/com/runto/domain/chat/application/ProducerService.java
@@ -1,0 +1,52 @@
+package com.runto.domain.chat.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.runto.domain.chat.dao.DirectChatRoomRepository;
+import com.runto.domain.chat.dto.MessageDTO;
+import com.runto.domain.chat.dto.MessageQueueDTO;
+import com.runto.domain.chat.exception.ChatException;
+import com.runto.domain.user.dao.UserRepository;
+import com.runto.domain.user.excepction.UserException;
+import com.runto.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProducerService {
+    private final RabbitTemplate rabbitTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final DirectChatRoomRepository directChatRoomRepository;
+    private final UserRepository userRepository;
+
+    @Value("${rabbit.exchange}")
+    private String exchange;
+
+    @Value("${rabbit.direct.routing}")
+    private String directRoutingKey;
+
+    public void sendDirectMessage(MessageDTO messageDTO, Long senderId){
+        if (!userRepository.existsById(senderId)){
+            throw new UserException(ErrorCode.USER_NOT_FOUND);
+        }
+        if (!directChatRoomRepository.existsById(messageDTO.getRoomId())){
+            throw new ChatException(ErrorCode.CHATROOM_NOT_FOUND);
+        }
+        log.info("Producer Service send Message = {}",messageDTO.getContent());
+        MessageQueueDTO messageQueueDTO = MessageQueueDTO.fromMessageDTO(messageDTO,senderId);
+
+        try {
+            String objectToJSON = objectMapper.writeValueAsString(messageQueueDTO);
+            rabbitTemplate.convertAndSend(exchange,
+                    directRoutingKey, objectToJSON);
+            log.info("Producer Service send Message to RabbitMQ = {}",messageQueueDTO.getContent());
+        }catch (JsonProcessingException e){
+            log.info("message parsing error to sendDirectMessage");
+        }
+    }
+}

--- a/src/main/java/com/runto/domain/chat/config/DataBaseCleanup.java
+++ b/src/main/java/com/runto/domain/chat/config/DataBaseCleanup.java
@@ -1,0 +1,21 @@
+package com.runto.domain.chat.config;
+
+import com.runto.domain.chat.dao.DirectMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataBaseCleanup implements CommandLineRunner {
+    private final DirectMessageRepository directMessageRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        //앱 재실행시 1:1채팅방 컬렉션 모두 삭제 초기화
+        //개발시 테스트 원활하게 하기 위한 용도입니다. 삭제예정
+        directMessageRepository.deleteAll();
+    }
+}

--- a/src/main/java/com/runto/domain/chat/config/RabbitmqConfig.java
+++ b/src/main/java/com/runto/domain/chat/config/RabbitmqConfig.java
@@ -1,0 +1,187 @@
+package com.runto.domain.chat.config;
+
+import com.rabbitmq.client.ShutdownSignalException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+
+@Configuration
+public class RabbitmqConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(RabbitmqConfig.class);
+    @Value("${spring.rabbitmq.host}")
+    private String host;
+
+    @Value("${spring.rabbitmq.username}")
+    private String username;
+
+    @Value("${spring.rabbitmq.password}")
+    private String password;
+
+    @Value("${spring.rabbitmq.port}")
+    private int port;
+
+    @Value("${rabbit.exchange}")
+    private String exchange;
+
+    @Value("${rabbit.direct.queue}")
+    private String directQueueName;
+
+    @Value("${rabbit.group.queue}")
+    private String groupQueueName;
+
+    @Value("${rabbit.direct.routing}")
+    private String directRoutingKey;
+
+    @Value("${rabbit.group.routing}")
+    private String groupRoutingKey;
+
+    @Value("${rabbit.dl.exchange}")
+    private String deadLetterExchange;
+
+    @Value("${rabbit.dl.queue}")
+    private String deadLetterQueue;
+
+    @Value("${rabbit.dl.routing}")
+    private String deadLetterRoutingKey;
+
+
+    @Bean
+    public ConnectionFactory connectionFactory(){
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+        connectionFactory.setHost(host);
+        connectionFactory.setPort(port);
+        connectionFactory.setUsername(username);
+        connectionFactory.setPassword(password);
+
+        connectionFactory.setChannelCacheSize(10);
+        connectionFactory.setCacheMode(CachingConnectionFactory.CacheMode.CHANNEL);
+        connectionFactory.setPublisherConfirmType(CachingConnectionFactory.ConfirmType.SIMPLE);
+        connectionFactory.setPublisherReturns(true);
+
+        connectionFactory.addConnectionListener(new ConnectionListener() {
+            @Override
+            public void onCreate(Connection connection) {
+                log.info("RabbitMQ connection created: {}",connection);
+            }
+
+            @Override
+            public void onShutDown(ShutdownSignalException signal) {
+                log.warn("RabbitMQ connection shut down: {}",signal.getMessage());
+            }
+
+            @Override
+            public void onFailed(Exception e) {
+                log.error("RabbitMQ connection failed: {}",e.getMessage());
+            }
+        });
+        return connectionFactory;
+    }
+
+    //메시지를 JSON 타입으로 변환하기 위한 컨버터 등록
+    @Bean
+    MessageConverter messageConverter(){
+        return new Jackson2JsonMessageConverter();
+    }
+
+    //메시지 송수신을 위한 템플릿
+    @Bean
+    RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter){
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+
+        SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy();
+        simpleRetryPolicy.setMaxAttempts(5);
+
+        //전송 실패시 재시도 템플릿
+        RetryTemplate retryTemplate = new RetryTemplate();
+        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(500); //첫번째 재시도 대기 시간
+        backOffPolicy.setMultiplier(2.0); // 대기 시간 증가 배율
+        backOffPolicy.setMaxInterval(10000);// 최대 대기 시간
+
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+        retryTemplate.setRetryPolicy(simpleRetryPolicy);
+
+        rabbitTemplate.setRetryTemplate(retryTemplate);
+        rabbitTemplate.setMessageConverter(messageConverter);
+
+        rabbitTemplate.setMandatory(true);
+        rabbitTemplate.setConfirmCallback(((correlationData, ack, cause) -> {
+            //메시지가 브로커에 도달했는지 확인
+            if (ack){
+                log.info("Message send success to RabbitMQ");
+            }else {
+                log.error("Message send failed to RabbitMQ = {}",cause);
+            }
+        }));
+        rabbitTemplate.setReturnsCallback(returnedMessage -> {
+            //메시지가 라우팅되지 않았을 경우
+            log.error("Message Return = {}",returnedMessage.getMessage());
+        });
+
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public DirectExchange directExchange(){
+        return new DirectExchange(exchange);
+    }
+
+    @Bean
+    public DirectExchange deadLetterExchange(){
+        return new DirectExchange(deadLetterExchange);
+    }
+
+    @Bean
+    public Queue directChatQueue(){
+        return QueueBuilder
+                .durable(directQueueName)
+                .ttl(90000)
+                .maxLengthBytes(1024 * 1024 * 5)
+                .build();
+    }
+
+    @Bean
+    public Binding directChatBinding(Queue directChatQueue, DirectExchange directExchange){
+        return BindingBuilder.bind(directChatQueue).to(directExchange).with(directRoutingKey);
+    }
+
+    @Bean
+    public Queue groupChatQueue(){
+        return QueueBuilder.durable(groupQueueName)
+                .ttl(90000)
+                .maxLengthBytes(1024 * 1024 * 5)
+                .build();
+    }
+
+    @Bean
+    public Binding groupChatBinding(Queue groupChatQueue, DirectExchange directExchange){
+        return BindingBuilder.bind(groupChatQueue).to(directExchange).with(groupRoutingKey);
+    }
+
+
+    @Bean Queue deadLetterQueue(){
+        return QueueBuilder.durable(deadLetterQueue).build();
+    }
+
+    @Bean
+    public Binding deadLetterBinding(Queue deadLetterQueue, DirectExchange deadLetterExchange){
+        return BindingBuilder.bind(deadLetterQueue).to(deadLetterExchange).with(deadLetterRoutingKey);
+    }
+
+
+}

--- a/src/main/java/com/runto/domain/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/runto/domain/chat/config/WebSocketConfig.java
@@ -1,0 +1,47 @@
+package com.runto.domain.chat.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins("http://localhost:3000")
+//                .setAllowedOrigins("https://runto.vercel.app/")
+                .withSockJS()
+                .setClientLibraryUrl("https://cdn.jsdelivr.net/sockjs/1.1.4/sockjs.min.js");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Bean
+    public RetryTemplate retryTemplate(){
+        RetryTemplate retryTemplate = new RetryTemplate();
+
+        SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy();
+        simpleRetryPolicy.setMaxAttempts(5);
+        retryTemplate.setRetryPolicy(simpleRetryPolicy);
+
+        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(500); //첫번째 재시도 대기 시간
+        backOffPolicy.setMultiplier(2.0); // 대기 시간 증가 배율
+        backOffPolicy.setMaxInterval(10000);// 최대 대기 시간
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+        return retryTemplate;
+    }
+}

--- a/src/main/java/com/runto/domain/chat/dao/DirectMessageRepository.java
+++ b/src/main/java/com/runto/domain/chat/dao/DirectMessageRepository.java
@@ -1,0 +1,7 @@
+package com.runto.domain.chat.dao;
+
+import com.runto.domain.chat.domain.DirectChatContent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface DirectMessageRepository extends MongoRepository<DirectChatContent,Long> {
+}

--- a/src/main/java/com/runto/domain/chat/domain/DirectChatContent.java
+++ b/src/main/java/com/runto/domain/chat/domain/DirectChatContent.java
@@ -1,0 +1,49 @@
+package com.runto.domain.chat.domain;
+
+import com.runto.domain.chat.dto.MessageQueueDTO;
+import com.runto.domain.chat.type.MessageStatus;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "direct_chat")
+public class DirectChatContent {
+    @Id
+    private String id;
+
+    @Field("room_id")
+    @Indexed
+    private Long roomId;
+
+    @Field("sender_id")
+    private Long senderId;
+
+    private String content;
+
+    private String timestamp;
+
+    @Field("status")
+    private MessageStatus messageStatus;
+
+    public static DirectChatContent of(MessageQueueDTO messageQueueDTO){
+        return DirectChatContent.builder()
+                .roomId(messageQueueDTO.getRoomId())
+                .senderId(messageQueueDTO.getSenderId())
+                .content(messageQueueDTO.getContent())
+                .timestamp(messageQueueDTO.getTimestamp())
+                .messageStatus(MessageStatus.SENT).build();
+    }
+
+    public void changeStatusToFailed(){
+        this.messageStatus = MessageStatus.FAILED;
+    }
+}

--- a/src/main/java/com/runto/domain/chat/dto/MessageDTO.java
+++ b/src/main/java/com/runto/domain/chat/dto/MessageDTO.java
@@ -1,0 +1,23 @@
+package com.runto.domain.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageDTO {
+    //클라이언트에서 메시지를 받는 용도
+    @NotNull(message = "roomId 는 null이 될 수 없습니다.")
+    private Long roomId;
+    private String content;
+    @Setter
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/runto/domain/chat/dto/MessageQueueDTO.java
+++ b/src/main/java/com/runto/domain/chat/dto/MessageQueueDTO.java
@@ -1,0 +1,26 @@
+package com.runto.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageQueueDTO {
+    //큐에 메시지 전송 혹은 큐에서 메시지를 받는 용도
+    private Long senderId;
+    private Long roomId;
+    private String content;
+    private String timestamp;
+
+    public static MessageQueueDTO fromMessageDTO(MessageDTO messageDTO,Long senderId){
+        return MessageQueueDTO.builder()
+                .senderId(senderId)
+                .roomId(messageDTO.getRoomId())
+                .content(messageDTO.getContent())
+                .timestamp(messageDTO.getTimestamp().toString()).build();
+    }
+}

--- a/src/main/java/com/runto/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/com/runto/domain/chat/dto/MessageResponse.java
@@ -1,0 +1,30 @@
+package com.runto.domain.chat.dto;
+
+import com.runto.domain.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageResponse {
+    //클라이언트에 응답하는 용도
+    private Long senderId;
+    private String senderName;
+    private String senderProfileImageUrl;
+    private String content;
+    private String timestamp;
+
+    public static MessageResponse of(MessageQueueDTO messageQueueDTO, User user){
+        return MessageResponse.builder()
+                .senderId(messageQueueDTO.getSenderId())
+                .senderName(user.getName())
+                .senderProfileImageUrl(user.getProfileImageUrl())
+                .content(messageQueueDTO.getContent())
+                .timestamp(messageQueueDTO.getTimestamp())
+                .build();
+    }
+}

--- a/src/main/java/com/runto/domain/chat/type/MessageStatus.java
+++ b/src/main/java/com/runto/domain/chat/type/MessageStatus.java
@@ -1,0 +1,6 @@
+package com.runto.domain.chat.type;
+
+public enum MessageStatus {
+    SENT,
+    FAILED
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,6 +35,16 @@ spring:
   jwt:
     secret: ${SECRET_KEY}
 
+  data:
+    mongodb:
+      uri: ${MONGO_DB_URI}
+
+  rabbitmq:
+    host: ${RABBIT_HOST}
+    username: ${RABBIT_USERNAME}
+    password: ${RABBIT_PASSWORD}
+    port: ${RABBIT_PORT}
+
   security:
     oauth2:
       client:
@@ -57,3 +67,16 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+rabbit:
+  exchange: ${RABBIT_EXCHANGE}
+  direct:
+    queue: ${DIRECT_QUEUE_NAME}
+    routing: ${DIRECT_ROUTING_KEY}
+  group:
+    queue: ${GROUP_QUEUE_NAME}
+    routing: ${GROUP_ROUTING_KEY}
+  dl:
+    exchange: ${RABBIT_DL_EXCHANGE}
+    queue: ${DEAD_LETTER_QUEUE}
+    routing: ${DEAD_LETTER_ROUTING_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,15 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
+    mongodb:
+      uri: ${MONGO_DB_URI}
+
+  rabbitmq:
+    host: ${RABBIT_HOST}
+    username: ${RABBIT_USERNAME}
+    password: ${RABBIT_PASSWORD}
+    port: ${RABBIT_PORT}
+
   security:
     oauth2:
       client:
@@ -71,3 +80,16 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+rabbit:
+  exchange: ${RABBIT_EXCHANGE}
+  direct:
+    queue: ${DIRECT_QUEUE_NAME}
+    routing: ${DIRECT_ROUTING_KEY}
+  group:
+    queue: ${GROUP_QUEUE_NAME}
+    routing: ${GROUP_ROUTING_KEY}
+  dl:
+    exchange: ${RABBIT_DL_EXCHANGE}
+    queue: ${DEAD_LETTER_QUEUE}
+    routing: ${DEAD_LETTER_ROUTING_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,29 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
+    mongodb:
+      uri: ${MONGO_DB_URI}
+
+  rabbitmq:
+    host: ${RABBIT_HOST}
+    username: ${RABBIT_USERNAME}
+    password: ${RABBIT_PASSWORD}
+    port: ${RABBIT_PORT}
+
 logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+rabbit:
+  exchange: ${RABBIT_EXCHANGE}
+  direct:
+    queue: ${DIRECT_QUEUE_NAME}
+    routing: ${DIRECT_ROUTING_KEY}
+  group:
+    queue: ${GROUP_QUEUE_NAME}
+    routing: ${GROUP_ROUTING_KEY}
+  dl:
+    exchange: ${RABBIT_DL_EXCHANGE}
+    queue: ${DEAD_LETTER_QUEUE}
+    routing: ${DEAD_LETTER_ROUTING_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,29 +50,7 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
-    mongodb:
-      uri: ${MONGO_DB_URI}
-
-  rabbitmq:
-    host: ${RABBIT_HOST}
-    username: ${RABBIT_USERNAME}
-    password: ${RABBIT_PASSWORD}
-    port: ${RABBIT_PORT}
-
 logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
-
-rabbit:
-  exchange: ${RABBIT_EXCHANGE}
-  direct:
-    queue: ${DIRECT_QUEUE_NAME}
-    routing: ${DIRECT_ROUTING_KEY}
-  group:
-    queue: ${GROUP_QUEUE_NAME}
-    routing: ${GROUP_ROUTING_KEY}
-  dl:
-    exchange: ${RABBIT_DL_EXCHANGE}
-    queue: ${DEAD_LETTER_QUEUE}
-    routing: ${DEAD_LETTER_ROUTING_KEY}


### PR DESCRIPTION

## 🔎 작업 내용
1:1 채팅을 구현했습니다..
현재는 Rest API를 통해 메시지 전송이 되나 테스트한 상태입니다.

__과정__
1. 메시지 전송 
2. Producer 메시지 생성 
3. Producer 메시지를 브로커로 전송 
4. RabbitMQ 내의 Exchange가 받음 
5. Exchange가 Queue에 라우팅해서 보내줌 
6. Queue 를 Consumer가 리스닝 (이때 Queue에서 메시지가 전송되지 못하고 남아있으면 DeadLetter)
7. Consumer 가 메시지를 받음 (소비) 
8. 메시지가 Queue에서 나감 
9. 메시지를 ConsumerService 에서 구독자들에게 메시지를 전송(클라이언트) 
(웹 소켓 메시지 전송은 재시도 정책에 의해 최대 5번까지 재시도) 
10. 전송이 실패 시 FAILED, 성공 시 SENT 로 상태값 변경 후 DB에 저장 

컨슈머 리스너 설정은 동시성허용 외에는 건드리지 않고 AUTO 설정 사용
동시성 값도 임의로 넣은거 뿐이고 기본값(1)으로 변경될 수 있음  

rabbitTemplate 에 RetryTemplate 과 다르게 웹 소켓 RetryTemplate 는 execute를 통해 직접 처리하도록 함.
  <br/>

## 이미지 첨부 (선)


<br/>

## 🔧 리뷰 요구사항
> .env 파일 변경사항 올리겠습니다
> 프로듀서 컨트롤러에 타임스탬프 부분은 프론트엔드에서 값을 받기로 했으나 현재 테스트를 위해 그냥 여기서 찍었음
> 웹소켓 메시지 전송은 아직 테스트를 못해봤음.. 따라서 수정될 여지가 있습니다
> DataBaseCleanup 파일도 삭제예정

<br/>
