### PR TITLE
✨ Feat(#58): 이벤트조회(목록, 상세) 기능 구현

### DIFF
--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -1,7 +1,10 @@
 package com.runto.domain.gathering.api;
 
 import com.runto.domain.gathering.application.GatheringService;
-import com.runto.domain.gathering.dto.*;
+import com.runto.domain.gathering.dto.CreateGatheringRequest;
+import com.runto.domain.gathering.dto.GatheringDetailResponse;
+import com.runto.domain.gathering.dto.GatheringsRequestParams;
+import com.runto.domain.gathering.dto.GatheringsResponse;
 import com.runto.global.security.detail.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -43,12 +46,14 @@ public class GatheringController {
         return ResponseEntity.ok().build();
     }
 
-    // TODO: 상세조회 시엔 DELETED, REPORTED는 노출 X
-    @Operation(summary = "모임 상세조회 [일반모임,  이벤트모임(아직 미적용)]")
+    @Operation(summary = "모임 상세조회 [일반모임,  이벤트모임]") // 같이 쓰게 된 이유는 pr 참조
     @GetMapping("/{gathering_id}")
     public ResponseEntity<GatheringDetailResponse> getGatheringDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("gathering_id") Long gatheringId) {
-        return ResponseEntity.ok(gatheringService.getGatheringDetail(gatheringId));
+
+        return ResponseEntity.ok(gatheringService
+                .getGatheringDetail(userDetails.getUserId(), gatheringId));
     }
 
     @Operation(summary = "모임목록 조회 [일반모임,  이벤트모임(아직 미적용)]")

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -56,7 +56,7 @@ public class GatheringController {
                 .getGatheringDetail(userDetails.getUserId(), gatheringId));
     }
 
-    @Operation(summary = "모임목록 조회 [일반모임,  이벤트모임(아직 미적용)]")
+    @Operation(summary = "모임목록 조회 [일반모임,  이벤트모임]")
     @GetMapping
     public ResponseEntity<GatheringsResponse> getGatherings(
             @Valid @ModelAttribute GatheringsRequestParams requestParams,

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -136,25 +136,25 @@ public class GatheringService {
         boolean isOrganizer = Objects.equals(gathering.getOrganizerId(), userId);
         GatheringStatus status = gathering.getStatus();
 
-        if(DELETED.equals(status)){
+        if (DELETED.equals(status)) {
             throw new GatheringException(GATHERING_NOT_FOUND);
         }
 
         // 신고당한 모임글 상세조회는 작성자만 볼 수 있음
-        if(!isOrganizer && REPORTED.equals(status)){
+        if (!isOrganizer && REPORTED.equals(status)) {
             throw new GatheringException(GATHERING_REPORTED);
         }
 
         // 승인되지 않은 이벤트모임은 주최자가 아니면 볼 수 없음
-        if(EVENT.equals(gathering.getGatheringType()) && // 이벤트인지 검증하는 조건이 무조건 먼저 들어가야함
-                !isApprovedEventForNonOrganizer(gathering.getEventGathering(), isOrganizer)){
+        if (EVENT.equals(gathering.getGatheringType()) && // 이벤트인지 검증하는 조건이 무조건 먼저 들어가야함
+                !isApprovedEventForNonOrganizer(gathering.getEventGathering(), isOrganizer)) {
             throw new GatheringException(EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW);
         }
     }
 
     private boolean isApprovedEventForNonOrganizer(EventGathering eventGathering, boolean isOrganizer) {
 
-        if(!isOrganizer){
+        if (!isOrganizer) {
             return APPROVED.equals(eventGathering.getStatus());
         }
         return true;
@@ -189,11 +189,16 @@ public class GatheringService {
 
     }
 
-    // 이벤트 목록 조회 조건 추가 예정
-    public GatheringsResponse getGatherings(GatheringsRequestParams requestParams, Pageable pageable) {
+    public GatheringsResponse getGatherings(GatheringsRequestParams params, Pageable pageable) {
 
         // 일반 모임인 경우
-        return GatheringsResponse.fromGeneralGatherings(gatheringRepository
-                .getGeneralGatherings(pageable, requestParams), requestParams);
+        if (GENERAL.equals(params.getGatheringType())) {
+            return GatheringsResponse.fromGeneralGatherings(gatheringRepository
+                    .getGeneralGatherings(pageable, params), params);
+        }
+
+        // 이벤트 모임인 경우
+        return GatheringsResponse.fromEventGatherings(gatheringRepository
+                .getEventGatherings(pageable, params), params);
     }
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -3,9 +3,11 @@ package com.runto.domain.gathering.application;
 
 import com.runto.domain.gathering.dao.EventGatheringRepository;
 import com.runto.domain.gathering.dao.GatheringRepository;
+import com.runto.domain.gathering.domain.EventGathering;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.dto.*;
 import com.runto.domain.gathering.exception.GatheringException;
+import com.runto.domain.gathering.type.GatheringStatus;
 import com.runto.domain.gathering.type.GatheringType;
 import com.runto.domain.image.application.ImageService;
 import com.runto.domain.image.domain.GatheringImage;
@@ -23,8 +25,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
+import static com.runto.domain.gathering.type.EventRequestStatus.APPROVED;
 import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
+import static com.runto.domain.gathering.type.GatheringStatus.*;
 import static com.runto.domain.gathering.type.GatheringType.EVENT;
 import static com.runto.domain.gathering.type.GatheringType.GENERAL;
 import static com.runto.global.exception.ErrorCode.*;
@@ -88,13 +93,13 @@ public class GatheringService {
         return gathering;
     }
 
-    // 커스텀 애노테이션 에러 해결되면 삭제
+    // TODO: 커스텀 애노테이션 에러 해결되면 삭제
     private void validateMaxNumber(GatheringType type, int maxNumber) {
         if (GENERAL.equals(type) && (maxNumber < 2 || maxNumber > 10)) {
             throw new GatheringException(GENERAL_MAX_NUMBER);
         }
         if (EVENT.equals(type) && (maxNumber < 10 || maxNumber > 300)) {
-            throw new GatheringException(EVENT_MAX_NUMBER);
+            throw new GatheringException(EVENT_GATHERING_MAX_NUMBER);
         }
     }
 
@@ -116,12 +121,43 @@ public class GatheringService {
         gathering.addContentImages(gatheringImages);
     }
 
-    public GatheringDetailResponse getGatheringDetail(Long gatheringId) {
+    public GatheringDetailResponse getGatheringDetail(Long userId, Long gatheringId) {
 
-        Gathering gathering = gatheringRepository.findGatheringDetailById(gatheringId)
+        Gathering gathering = gatheringRepository.findGatheringById(gatheringId)
                 .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
 
-        return GatheringDetailResponse.from(gathering);
+        checkGatheringAccessibility(userId, gathering);
+        return GatheringDetailResponse.fromGathering(gathering);
+
+    }
+
+    private void checkGatheringAccessibility(Long userId, Gathering gathering) {
+
+        boolean isOrganizer = Objects.equals(gathering.getOrganizerId(), userId);
+        GatheringStatus status = gathering.getStatus();
+
+        if(DELETED.equals(status)){
+            throw new GatheringException(GATHERING_NOT_FOUND);
+        }
+
+        // 신고당한 모임글 상세조회는 작성자만 볼 수 있음
+        if(!isOrganizer && REPORTED.equals(status)){
+            throw new GatheringException(GATHERING_REPORTED);
+        }
+
+        // 승인되지 않은 이벤트모임은 주최자가 아니면 볼 수 없음
+        if(EVENT.equals(gathering.getGatheringType()) && // 이벤트인지 검증하는 조건이 무조건 먼저 들어가야함
+                !isApprovedEventForNonOrganizer(gathering.getEventGathering(), isOrganizer)){
+            throw new GatheringException(EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW);
+        }
+    }
+
+    private boolean isApprovedEventForNonOrganizer(EventGathering eventGathering, boolean isOrganizer) {
+
+        if(!isOrganizer){
+            return APPROVED.equals(eventGathering.getStatus());
+        }
+        return true;
     }
 
 

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
@@ -13,8 +13,7 @@ import java.util.Optional;
 public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringRepositoryCustom {
 
     @Query("select g from Gathering g " +
-            " join fetch g.gatheringMembers gm " +
-            " join fetch gm.user " +
+            " left join fetch g.eventGathering " +
             " where g.id= :gathering_id ")
-    Optional<Gathering> findGatheringDetailById(@Param("gathering_id") Long gatheringId);
+    Optional<Gathering> findGatheringById(@Param("gathering_id") Long gatheringId);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
@@ -25,4 +25,7 @@ public interface GatheringRepositoryCustom {
 
     Slice<Gathering> getGeneralGatherings(Pageable pageable,
                                           GatheringsRequestParams requestParams);
+
+    Slice<Gathering> getEventGatherings(Pageable pageable,
+                                        GatheringsRequestParams param);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -39,6 +39,7 @@ import static com.runto.domain.gathering.type.GatheringType.EVENT;
 import static com.runto.domain.gathering.type.GatheringType.GENERAL;
 import static com.runto.domain.gathering.type.ParticipationEligibility.AVAILABLE;
 import static com.runto.domain.gathering.type.ParticipationEligibility.NOT_AVAILABLE;
+import static com.runto.domain.user.domain.QUser.user;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 
 @RequiredArgsConstructor
@@ -47,15 +48,15 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    
-    // TODO: 일반모임목록 조회쿼리에 user 까지 패치조인 필요
+
     @Override
     public Slice<Gathering> getUserGeneralGatherings(Long userId,
                                                      Pageable pageable,
                                                      UserGatheringsRequestParams request) {
 
         List<Gathering> gatherings = jpaQueryFactory.selectFrom(gathering)
-                .join(gathering.gatheringMembers).fetchJoin()
+                .join(gathering.gatheringMembers, gatheringMember).fetchJoin()
+                .join(gatheringMember.user, user).fetchJoin()
                 .where(
                         memberRoleCondition(userId, request.getMemberRole()),
                         timeCondition(request.getGatheringTimeStatus()),
@@ -70,20 +71,13 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
         return new SliceImpl<>(gatherings, pageable, hasNextPage(pageable, gatherings));
     }
 
-    /**
-     * 양방향으로 바꾸면서 getUserGeneralGatherings 과 한개의 조건을 제외하고 완전히 똑같아서,
-     * <p>
-     * eventGathering.status 에 대한 condition을 따로 만들고(일반 모임은 null로 반환하면 되니까)
-     * 두 메서드를 합쳐서 쓸까 했지만
-     * 일반모임 조회일때도 eventGathering.status 에 대한 조건 로직이 들어가는게 뭔가 이상해보여서 그만두었음
-     */
     @Override
     public Slice<Gathering> getUserEventGatherings(Long userId,
                                                    Pageable pageable,
                                                    UserGatheringsRequestParams request) {
 
         List<Gathering> gatherings = jpaQueryFactory.selectFrom(gathering)
-                .join(gathering).fetchJoin()
+                .join(gathering.eventGathering).fetchJoin()
                 .where(
                         memberRoleCondition(userId, request.getMemberRole()),
                         timeCondition(request.getGatheringTimeStatus()),
@@ -119,12 +113,14 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
                 .fetch();
     }
 
+
     @Override
     public Slice<Gathering> getGeneralGatherings(Pageable pageable,
                                                  GatheringsRequestParams param) {
 
         List<Gathering> gatherings = jpaQueryFactory.selectFrom(gathering)
-                .join(gathering.gatheringMembers).fetchJoin()
+                .join(gathering.gatheringMembers, gatheringMember).fetchJoin()
+                .join(gatheringMember.user, user).fetchJoin()
                 .where(
                         gatheringTypeCondition(GENERAL),
                         participationCondition(param.getParticipationEligibility()), // 참가가능상태
@@ -133,6 +129,30 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
                         goalDistanceCondition(param.getGoalDistance()), // 목표거리
                         runningConceptCondition(param.getRunningConcept()), // 러닝컨셉
                         radiusDistanceCondition(param.getRadiusDistance(), param.getX(), param.getY()) // 좌표 기준 X km 반경
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1) // 다음 페이지에 가져올 컨텐츠가 있는지 확인하기 위함
+                .orderBy(orderCondition(param.getOrderBy(), param.getSortDirection()))
+                .fetch();
+
+        return new SliceImpl<>(gatherings, pageable, hasNextPage(pageable, gatherings));
+    }
+
+    @Override
+    public Slice<Gathering> getEventGatherings(Pageable pageable,
+                                                 GatheringsRequestParams param) {
+
+        List<Gathering> gatherings = jpaQueryFactory.selectFrom(gathering)
+                .join(gathering.eventGathering).fetchJoin()
+                .where(
+                        gatheringTypeCondition(EVENT),
+                        participationCondition(param.getParticipationEligibility()), // 참가가능상태
+                        searchTitleCondition(param.getSearchTitle()), // 제목검색
+                        statusCondition(null), // 모임글 상태 (목록 조회는 삭제 외 모두 노출)
+                        goalDistanceCondition(param.getGoalDistance()), // 목표거리
+                        runningConceptCondition(param.getRunningConcept()), // 러닝컨셉
+                        radiusDistanceCondition(param.getRadiusDistance(), param.getX(), param.getY()), // 좌표 기준 X km 반경
+                        eventStatusCondition(APPROVED)
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1) // 다음 페이지에 가져올 컨텐츠가 있는지 확인하기 위함

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -7,7 +7,9 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.domain.QCoordinates;
-import com.runto.domain.gathering.dto.*;
+import com.runto.domain.gathering.dto.GatheringMember;
+import com.runto.domain.gathering.dto.GatheringsRequestParams;
+import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
 import com.runto.domain.gathering.type.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -26,11 +28,11 @@ import static com.runto.domain.common.SortUtil.getOrderSpecifier;
 import static com.runto.domain.gathering.domain.QEventGathering.eventGathering;
 import static com.runto.domain.gathering.domain.QGathering.gathering;
 import static com.runto.domain.gathering.dto.QGatheringMember.gatheringMember;
-import static com.runto.domain.gathering.type.EventRequestStatus.*;
+import static com.runto.domain.gathering.type.EventRequestStatus.APPROVED;
 import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
 import static com.runto.domain.gathering.type.GatheringMemberRole.PARTICIPANT;
 import static com.runto.domain.gathering.type.GatheringOrderField.APPOINTED_AT;
-import static com.runto.domain.gathering.type.GatheringStatus.*;
+import static com.runto.domain.gathering.type.GatheringStatus.DELETED;
 import static com.runto.domain.gathering.type.GatheringTimeStatus.ENDED;
 import static com.runto.domain.gathering.type.GatheringTimeStatus.ONGOING;
 import static com.runto.domain.gathering.type.GatheringType.EVENT;
@@ -46,7 +48,7 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
     private final JPAQueryFactory jpaQueryFactory;
 
     
-    // TODO: 모든 모임글조회쿼리에 user 까지 패치조인 필요
+    // TODO: 일반모임목록 조회쿼리에 user 까지 패치조인 필요
     @Override
     public Slice<Gathering> getUserGeneralGatherings(Long userId,
                                                      Pageable pageable,
@@ -121,14 +123,13 @@ public class GatheringRepositoryCustomImpl implements GatheringRepositoryCustom 
     public Slice<Gathering> getGeneralGatherings(Pageable pageable,
                                                  GatheringsRequestParams param) {
 
-
         List<Gathering> gatherings = jpaQueryFactory.selectFrom(gathering)
                 .join(gathering.gatheringMembers).fetchJoin()
                 .where(
                         gatheringTypeCondition(GENERAL),
                         participationCondition(param.getParticipationEligibility()), // 참가가능상태
                         searchTitleCondition(param.getSearchTitle()), // 제목검색
-                        statusCondition(null), // 모임글 상태
+                        statusCondition(null), // 모임글 상태 (목록 조회는 삭제 외 모두 노출)
                         goalDistanceCondition(param.getGoalDistance()), // 목표거리
                         runningConceptCondition(param.getRunningConcept()), // 러닝컨셉
                         radiusDistanceCondition(param.getRadiusDistance(), param.getX(), param.getY()) // 좌표 기준 X km 반경

--- a/src/main/java/com/runto/domain/gathering/domain/Gathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Gathering.java
@@ -119,7 +119,7 @@ public class Gathering extends BaseTimeEntity {
     // 해당 모임을 이벤트모임으로 신청
     public void applyForEvent() {
         if (maxNumber < 10 || maxNumber > 300) {
-            throw new GatheringException(EVENT_MAX_NUMBER);
+            throw new GatheringException(EVENT_GATHERING_MAX_NUMBER);
         }
         this.eventGathering = new EventGathering(this);
     }

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringDetailContentResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringDetailContentResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.type.GatheringStatus;
+import com.runto.domain.gathering.type.GatheringType;
 import com.runto.domain.gathering.type.GoalDistance;
 import com.runto.domain.gathering.type.RunningConcept;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,8 @@ import java.time.LocalDateTime;
 public class GatheringDetailContentResponse { // 이벤트 상세조회 시에도 사용될 예정
 
     private Long id;
+
+    private GatheringType type;
 
     private Long organizerId;
 
@@ -52,6 +55,7 @@ public class GatheringDetailContentResponse { // 이벤트 상세조회 시에�
     public static GatheringDetailContentResponse from(Gathering gathering) {
         return GatheringDetailContentResponse.builder()
                 .id(gathering.getId())
+                .type(gathering.getGatheringType())
                 .organizerId(gathering.getOrganizerId())
                 .title(gathering.getTitle())
                 .description(gathering.getDescription())

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringDetailResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringDetailResponse.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 
 @Builder
@@ -16,17 +14,15 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @NoArgsConstructor
 @JsonNaming(SnakeCaseStrategy.class)
 @Getter
-public class GatheringDetailResponse { // 이벤트 상세조회 시에도 사용될 예정
+public class GatheringDetailResponse { // 멤버목록 가져오기는 api 분리로 수정
 
     private GatheringDetailContentResponse gatheringContentResponse;
-    private List<GatheringMemberResponse> gatheringMembers;
 
     
-    public static GatheringDetailResponse from(Gathering gathering) {
+    public static GatheringDetailResponse fromGathering(Gathering gathering) {
 
         return GatheringDetailResponse.builder()
                 .gatheringContentResponse(GatheringDetailContentResponse.from(gathering))
-                .gatheringMembers(GatheringMemberResponse.from(gathering.getGatheringMembers()))
                 .build();
     }
 

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringResponse.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.runto.domain.gathering.type.GatheringStatus.REPORTED;
+
 @Slf4j
 @Builder
 @AllArgsConstructor
@@ -51,6 +53,12 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
                 .map(member -> member.getUser().getProfileImageUrl())
                 .toList();
 
+        // 신고상태면 썸네일은 내보내지 않음
+        String thumbnailUrl = null;
+        if(!REPORTED.equals(gathering.getStatus())){
+            thumbnailUrl = gathering.getThumbnailUrl();
+        }
+
         return GatheringResponse.builder()
                 .id(gathering.getId())
                 .organizerId(gathering.getOrganizerId())
@@ -59,7 +67,7 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
                 .deadline(gathering.getDeadline())
                 .concept(gathering.getConcept())
                 .goalDistance(gathering.getGoalDistance())
-                .thumbnailUrl(gathering.getThumbnailUrl())
+                .thumbnailUrl(thumbnailUrl)
                 .hits(gathering.getHits())
                 .location(LocationDto.from(gathering.getLocation()))
                 .status(gathering.getStatus())
@@ -72,6 +80,12 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
 
     public static GatheringResponse fromEventGathering(Gathering gathering) {
 
+        // 신고상태면 썸네일은 내보내지 않음
+        String thumbnailUrl = null;
+        if(!REPORTED.equals(gathering.getStatus())){
+            thumbnailUrl = gathering.getThumbnailUrl();
+        }
+
         return GatheringResponse.builder()
                 .id(gathering.getId())
                 .organizerId(gathering.getOrganizerId())
@@ -80,7 +94,7 @@ public class GatheringResponse { // 다른 목록조회에서도 쓸 예정
                 .deadline(gathering.getDeadline())
                 .concept(gathering.getConcept())
                 .goalDistance(gathering.getGoalDistance())
-                .thumbnailUrl(gathering.getThumbnailUrl())
+                .thumbnailUrl(thumbnailUrl)
                 .hits(gathering.getHits())
                 .location(LocationDto.from(gathering.getLocation()))
                 .status(gathering.getStatus())

--- a/src/main/java/com/runto/domain/gathering/type/GatheringStatus.java
+++ b/src/main/java/com/runto/domain/gathering/type/GatheringStatus.java
@@ -7,5 +7,5 @@ public enum GatheringStatus {
     NORMAL,   // 정상
     DELETED,  // 삭제
     REPORTED, // 신고
-    COMPLETED // 완료
+
 }

--- a/src/main/java/com/runto/domain/user/api/UserController.java
+++ b/src/main/java/com/runto/domain/user/api/UserController.java
@@ -65,7 +65,7 @@ public class UserController {
     }
 
     @Operation(summary = "내 이벤트 신청목록 조회")
-    @GetMapping("/events")
+    @GetMapping("/gatherings/events")
     public ResponseEntity<UserEventGatheringsResponse> getMyEventRequests(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 8) Pageable pageable) {

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -15,8 +15,10 @@ public enum ErrorCode {
 
     // 모임글 & 이벤트 관련
     GATHERING_NOT_FOUND(NOT_FOUND, "존재하지 않는 모임글입니다."),
+    GATHERING_REPORTED(FORBIDDEN, "신고당한 모임글입니다."),
+    EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW(FORBIDDEN,"승인상태가 아닌 이벤트모임은 주최자 본인만 볼 수 있습니다."),
     GENERAL_MAX_NUMBER(BAD_REQUEST, "일반 모임의 최대 인원은 2명에서 10명 사이여야 합니다."),
-    EVENT_MAX_NUMBER(BAD_REQUEST, "이벤트 모임의 최대 인원은 10명에서 300명 사이여야 합니다."),
+    EVENT_GATHERING_MAX_NUMBER(BAD_REQUEST, "이벤트 모임의 최대 인원은 10명에서 300명 사이여야 합니다."),
 
 
     // 채팅관련,

--- a/src/main/java/com/runto/test_api/RadiusTestDataInit.java
+++ b/src/main/java/com/runto/test_api/RadiusTestDataInit.java
@@ -37,7 +37,7 @@ public class RadiusTestDataInit {
 
     private final GatheringRepository gatheringRepository;
 
-    @EventListener(ApplicationReadyEvent.class)
+    //@EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void init() {
 
@@ -124,9 +124,10 @@ public class RadiusTestDataInit {
                     .status(NORMAL)
                     .maxNumber(10)
                     .currentNumber(1)
-                    .gatheringType(GatheringType.GENERAL)
+                    .gatheringType(GatheringType.EVENT)
                     .build();
             gathering.addMember(users.get(0), ORGANIZER);
+            gathering.applyForEvent();
 
             // 0번 유저는 주최자
             for (int j = 1; j < users.size(); j++) {

--- a/src/main/java/com/runto/test_api/TestDataInit.java
+++ b/src/main/java/com/runto/test_api/TestDataInit.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
 import static com.runto.domain.gathering.type.GatheringMemberRole.PARTICIPANT;
+import static com.runto.domain.user.type.Gender.MAN;
 import static com.runto.domain.user.type.Gender.WOMAN;
 
 @RequiredArgsConstructor
@@ -35,31 +36,37 @@ public class TestDataInit {
 
     private final GatheringRepository gatheringRepository;
 
-    //@EventListener(ApplicationReadyEvent.class)
+    @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void init() {
 
         String password = bCryptPasswordEncoder.encode("123456");
 
         List<User> users = new ArrayList<>();
+        List<Gathering> gatherings = new ArrayList<>();
 
-        for (int i = 0; i < 10; i++) {
+
+        // 회원 세팅
+        for (int i = 1; i <= 10; i++) {
+
             LocalAccount localAccount = LocalAccount.builder()
                     .password(password)
                     .build();
 
-            users.add(User.builder()
+            User user = User.builder()
                     .email("runto" + i + "@gmail.com")
-                    .name("테스트유저이름" + i + 1)
-                    .nickname("테스트유저닉네임" + i + 1)
-                    .gender(WOMAN)
+                    .name("테스트유저이름" + i)
+                    .nickname("테스트유저닉네임" + i)
+                    .gender(MAN)
                     //.status()
                     .localAccount(localAccount)
                     .role(UserRole.USER)
-                    .profileImageUrl(i + 1 + "번유저 썸네일 url")
-                    .build());
+                    .profileImageUrl(i+ "번유저 썸네일 url")
+                    .build();
+
+            users.add(user);
+            userRepository.saveAll(users);
         }
-        users = userRepository.saveAll(users);
 
 
         Location location = Location
@@ -70,13 +77,12 @@ public class TestDataInit {
                         new RegionCode(0, 0),
                         new Coordinates(0.0, 0.0));
 
-        List<Gathering> gatherings = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
             Gathering gathering = Gathering.builder()
                     .organizerId(users.get(i).getId())
-                    .title("(기한 남음) 우리 모두 달립시다 " + i)
-                    .description("재밌게 달려봅시다." + i)
+                    .title("(기한 남음) 우리 모두 달립시다 - runto" + (i+1) + "유저")
+                    .description("재밌게 달려봅시다.")
                     .appointedAt(LocalDateTime.now().plusDays(i + 2))
                     .deadline(LocalDateTime.now().plusDays(i + 1))
                     .concept(RunningConcept.HEALTH)
@@ -89,7 +95,6 @@ public class TestDataInit {
                     .currentNumber(1)
                     .gatheringType(GatheringType.GENERAL)
                     .build();
-
             gathering.addMember(users.get(i), ORGANIZER);
 
             for (int j = 0; j < 10; j++) {
@@ -106,7 +111,7 @@ public class TestDataInit {
         for (int i = 0; i < 10; i++) {
             Gathering gathering = Gathering.builder()
                     .organizerId(users.get(i).getId())
-                    .title("(기한 만료) 우리 모두 달립시다 " + i)
+                    .title("(기한 만료) 우리 모두 달립시다 - runto" + (i+1) + "유저")
                     .description("재밌게 달려봅시다." + i)
                     .appointedAt(LocalDateTime.now().minusDays(i + 2))
                     .deadline(LocalDateTime.now().minusDays(i + 1))
@@ -135,8 +140,6 @@ public class TestDataInit {
             gatherings.add(gathering);
         }
 
-
-        gatherings = gatheringRepository.saveAll(gatherings);
-
+        gatheringRepository.saveAll(gatherings);
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- ### 이벤트 목록 조회
- ### 이벤트 상세 조회

- ### 기존의 일반목록, 상세 조회 리팩토링 과정(생각의 흐름) 
  리팩토링 동시에 이벤트 조회가 이루어짐
  
  현재 일반, 이벤트는 type 필드로 분류하고 있을 뿐 ``같은 Gathering 데이터`` 
  ``일반모임의 경우 최대인원이 10명`` -> 목록, 상세보기에서 같이 패치조인으로 한번에 가져와도 무방
  
  ``일반모임``목록 조회시 화면에서 멤버의 프로필 이미지를 모두 나열하기때문에 ``구성원목록``도 같이 패치조인으로 한번에 가져왔음
  
  하지만 이벤트모임의 경우 최대 인원이 백 단위로 넘어가면서 한번에 가져오는 것은 아니라고 판단
  -> ``이벤트 모임목록 조회`` 시엔 멤버를 아예 안 가져오고 프론트에 띄우지않기로했었음
  
  ``모임목록 조회``가 아예 ``일반모임``, ``이벤트모임`` 조회가 완전히 분리하기로 해서, 
  프론트로부터 해당 요청이 일반모임인지, 이벤트모임에 관한것인지 type 값을 받아서 조회할 수 있었음
  처음부터 ``멤버목록``을 같이 패치조인해야할지, 안해야할지 결정해서 쿼리문을 날릴 수 있었음
  
  ### 하지만? 
  상세조회의 경우는 ``Gathering id``(pk) 만 받아서 조회를 하기때문에, db에서 꺼내오기전까진
  해당 모임이 ``일반모임``인지, ``이벤트모임``인지에 대해서는 알 수가 없음
  
  하지만 그렇다고 모임만 먼저 가져오고 타입을 확인 뒤 ``구성원목록``을 가져올지를 결정하면,
  일반모임 상세조회 시 무조건 쿼리문을 한번 더 날려야함
  
  상세조회시 이미지url을 가져오는것에 대해 api를 분리했기때문에 처음 조회를 하는데 무조건 세 번은 db를 오가야하지 않나? 라고 판단
  
  
  그러면 차라리 ``구성원목록``을 가져오는 것에 대해 사용자에게 선택지를 주는게 어떨까?
  
  예를 들어 ``상세조회``를 하면 ``일단 api 두번 요청(콘텐츠 내용, 이미지)`` -> 로직 상 기본 db 를 두 번은 오감
  
  위의 api요청 후 응답을 받아서 화면이 띄워지고나서 
  이 상태에서 사용자가 ``참여구성원보기버튼`` 같은 것을 누르지 않는다면, 2번에서 끝남 (궁금해서 누를때 만 총 3번)**
  
  ### ``모임 구성원목록 가져오기``를 분리할때의 장점
  
누락된 로직이 있을 수 있기때문에 횟수는 더 많을 수도 있음
  ``일반모임``의 경우 ``구성원목록 가져오기``를 분리 X ->  처음 조회시 db 에 오가는 횟수 3번
  ``일반모임``의 경우 ``구성원목록 가져오기``를 분리 0 -> 처음 조회시 db 에 오가는 횟수 기본 2번, 최대 3번
  
  원래는 이벤트의 경우 멤버목록 자체를 제공하지 않을까 생각도 했었으나,
  분리 시 이벤트모임 상세조회에 멤버가져오기를 제공해줄 수 있게 됨 (페이징으로)
  
  위와 같은 이유로 상세조회는 ``구성원목록 가져오기``를 분리하는게 더 낫다고 판단
  그리고 만약 정책상 일반모임의 최대인원수가 증가될 수도 있을 가능성을 고려했을 때도 낫다고 판단

### 근데 작업을 하다보니, 생각이 바뀐 것 같습니다...  #115 에서 큰 글씨 참고
<br/>
closed #58 
