### PR TITLE
✨ Feat(#74): 1:1 채팅방 조회

### DIFF
--- a/src/main/java/com/runto/domain/chat/api/DirectChatController.java
+++ b/src/main/java/com/runto/domain/chat/api/DirectChatController.java
@@ -3,10 +3,10 @@ package com.runto.domain.chat.api;
 import com.runto.domain.chat.application.DirectChatService;
 import com.runto.domain.chat.dto.DirectChatInfoDTO;
 import com.runto.domain.chat.dto.DirectChatRoomResponse;
+import com.runto.domain.chat.dto.MessageResponse;
 import com.runto.global.security.detail.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,11 +21,13 @@ public class DirectChatController {
 
     //1:1 채팅방 1:1채팅하기로 조회(생성과 같이 있음)
     @GetMapping
-    public ResponseEntity<DirectChatInfoDTO> getDirectChatRoom(@RequestParam(name = "other_id") Long otherId,
-                                                  @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<Slice<MessageResponse>> getDirectChatRoom(@RequestParam(name = "other_id") Long otherId,
+                                                                    @RequestParam(name = "page_num") int pageNum,
+                                                                    @RequestParam(defaultValue = "7") int size,
+                                                                    @AuthenticationPrincipal CustomUserDetails userDetails){
         DirectChatInfoDTO directChatInfoDTO = directChatService.createAndGetDirectChat(userDetails.getUserId(),otherId);
-        //TODO 채팅방 정보를 통한 이전 채팅 메시지 보여주기,
-        return ResponseEntity.ok(directChatInfoDTO);
+        Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(directChatInfoDTO.getRoomId(),pageNum,size);
+        return ResponseEntity.ok(messageResponses);
     }
 
     //1:1 채팅방 목록 조회
@@ -36,11 +38,13 @@ public class DirectChatController {
         return ResponseEntity.ok(directChatService.getDirectChatRoomList(userDetails.getUserId(), pageNum,size));
     }
 
-    //TODO 1:1 채팅방 목록에서 눌러서 채팅방 조회
+    //1:1 채팅방 조회 (목록에서)
     @GetMapping("/{room_id}")
-    public ResponseEntity<Void> getDirectChatRoomFromList(@PathVariable(name = "room_id") Long roomId){
-        //TODO 채팅방 정보를 통한 이전 채팅 메시지 보여주기
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Slice<MessageResponse>> getDirectChatRoomFromList(@PathVariable(name = "room_id") Long roomId,
+                                                          @RequestParam(name = "page_num") int pageNum,
+                                                          @RequestParam(defaultValue = "7") int size){
+        Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(roomId,pageNum,size);
+        return ResponseEntity.ok(messageResponses);
     }
 
 }

--- a/src/main/java/com/runto/domain/chat/config/RabbitmqConfig.java
+++ b/src/main/java/com/runto/domain/chat/config/RabbitmqConfig.java
@@ -18,6 +18,9 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
+import java.util.HashMap;
+import java.util.Map;
+
 
 @Configuration
 public class RabbitmqConfig {
@@ -148,8 +151,12 @@ public class RabbitmqConfig {
 
     @Bean
     public Queue directChatQueue(){
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-dead-letter-exchange", deadLetterExchange);
+        args.put("x-dead-letter-routing-key", deadLetterRoutingKey);
         return QueueBuilder
                 .durable(directQueueName)
+                .withArguments(args)
                 .ttl(90000)
                 .maxLengthBytes(1024 * 1024 * 5)
                 .build();
@@ -162,7 +169,11 @@ public class RabbitmqConfig {
 
     @Bean
     public Queue groupChatQueue(){
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-dead-letter-exchange", deadLetterExchange);
+        args.put("x-dead-letter-routing-key", deadLetterRoutingKey);
         return QueueBuilder.durable(groupQueueName)
+                .withArguments(args)
                 .ttl(90000)
                 .maxLengthBytes(1024 * 1024 * 5)
                 .build();

--- a/src/main/java/com/runto/domain/chat/dao/DirectMessageRepository.java
+++ b/src/main/java/com/runto/domain/chat/dao/DirectMessageRepository.java
@@ -1,7 +1,14 @@
 package com.runto.domain.chat.dao;
 
 import com.runto.domain.chat.domain.DirectChatContent;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.time.LocalDateTime;
 
 public interface DirectMessageRepository extends MongoRepository<DirectChatContent,Long> {
+    @Query("{'room_id' : ?0, 'status': 'SENT', 'timestamp' :  {$gte : ?1} }")
+    Slice<DirectChatContent> findDirectChatContent(Long roomId, LocalDateTime daysAgo, Pageable pageable);
 }

--- a/src/main/java/com/runto/domain/chat/domain/DirectChatContent.java
+++ b/src/main/java/com/runto/domain/chat/domain/DirectChatContent.java
@@ -11,6 +11,9 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Builder
 @Getter
 @NoArgsConstructor
@@ -29,17 +32,18 @@ public class DirectChatContent {
 
     private String content;
 
-    private String timestamp;
+    private LocalDateTime timestamp;
 
     @Field("status")
     private MessageStatus messageStatus;
 
     public static DirectChatContent of(MessageQueueDTO messageQueueDTO){
+        LocalDateTime timestamp = LocalDateTime.parse(messageQueueDTO.getTimestamp(),DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         return DirectChatContent.builder()
                 .roomId(messageQueueDTO.getRoomId())
                 .senderId(messageQueueDTO.getSenderId())
                 .content(messageQueueDTO.getContent())
-                .timestamp(messageQueueDTO.getTimestamp())
+                .timestamp(timestamp)
                 .messageStatus(MessageStatus.SENT).build();
     }
 

--- a/src/main/java/com/runto/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/com/runto/domain/chat/dto/MessageResponse.java
@@ -1,5 +1,6 @@
 package com.runto.domain.chat.dto;
 
+import com.runto.domain.chat.domain.DirectChatContent;
 import com.runto.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,7 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MessageResponse {
-    //클라이언트에 응답하는 용도
     private Long senderId;
     private String senderName;
     private String senderProfileImageUrl;
@@ -25,6 +25,16 @@ public class MessageResponse {
                 .senderProfileImageUrl(user.getProfileImageUrl())
                 .content(messageQueueDTO.getContent())
                 .timestamp(messageQueueDTO.getTimestamp())
+                .build();
+    }
+
+    public static MessageResponse of(DirectChatContent directChatContent, User user){
+        return MessageResponse.builder()
+                .senderId(directChatContent.getSenderId())
+                .senderName(user.getName())
+                .senderProfileImageUrl(user.getProfileImageUrl())
+                .content(directChatContent.getContent())
+                .timestamp(directChatContent.getTimestamp().toString())
                 .build();
     }
 }


### PR DESCRIPTION


## 🔎 작업 내용
목록에서 조회, 1:1 채팅하기로 조회  구현


## 이미지 첨부 (선)


<br/>

## 🔧 기타
__데드레터 큐는 보류__
API 테스팅중에 rabbimq에 연결된 커넥션 (스프링부트 켜진 수)가 많아질수록 RabbitMQ에는 전송이 되는데
메시지가 소비되지 않는 일이 발생했다 -> 
원인은 알수 없음 ec2 메모리문제? mq 메모리문제? 
아무튼 이런 문제가 발생했는데
컨슈머 서비스에서 ACK 모드를 수동으로 하고 처리를 해놔도 딱히 로그가 발생하지 않았음..
커넥션 자체에서 생기는 문제라 이후에 과정이 진행되지 않는듯한 느낌?

아무튼 데드레터 큐 설정은 추가로 해놨으나 임시로 해놓은거고 제대로 되는지 확인도 아직 못함.. 
어떻게 사용할지도 일단 보류


<br/>
