### PR TITLE
✨Feature( #89): 출석체크 & 모임완료 기능(일반모임, 이벤트모임)

### DIFF
--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -50,8 +52,8 @@ public class GatheringController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("gathering_id") Long gatheringId) {
 
-        return ResponseEntity.ok(gatheringService
-                .getGatheringDetail(userDetails.getUserId(), gatheringId));
+        return ResponseEntity.ok(gatheringService.
+                getGatheringDetail(userDetails.getUserId(), gatheringId));
     }
 
     @Operation(summary = "모임목록 조회 [일반모임,  이벤트모임]")
@@ -70,7 +72,20 @@ public class GatheringController {
             @PathVariable("gathering_id") Long gatheringId,
             @PageableDefault(size = 10) Pageable pageable) {
 
-        return ResponseEntity.ok(gatheringService
-                .getGatheringMembers(gatheringId, pageable));
+        return ResponseEntity.ok(gatheringService.
+                getGatheringMembers(gatheringId, pageable));
     }
+
+    @Operation(summary = "구성원 출석체크 [일반모임]")
+    @PostMapping("/{gathering_id}/members/attendance")
+    public ResponseEntity<List<MemberAttendanceStatusDto>> checkAttendanceMembers(
+            @PathVariable("gathering_id") Long gatheringId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody List<MemberAttendanceStatusDto> requestList) {
+
+        return ResponseEntity.ok(
+                gatheringService.checkAttendanceGeneralGatheringMembers(
+                        userDetails.getUserId(), gatheringId, requestList));
+    }
+
 }

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -46,7 +46,7 @@ public class GatheringController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "모임 상세조회 [일반모임,  이벤트모임]") // 같이 쓰게 된 이유는 pr 참조
+    @Operation(summary = "모임 상세조회 [일반모임, 이벤트모임]") // 같이 쓰게 된 이유는 pr 참조
     @GetMapping("/{gathering_id}")
     public ResponseEntity<GatheringDetailResponse> getGatheringDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -56,7 +56,7 @@ public class GatheringController {
                 getGatheringDetail(userDetails.getUserId(), gatheringId));
     }
 
-    @Operation(summary = "모임목록 조회 [일반모임,  이벤트모임]")
+    @Operation(summary = "모임목록 조회 [일반모임, 이벤트모임]")
     @GetMapping
     public ResponseEntity<GatheringsResponse> getGatherings(
             @Valid @ModelAttribute GatheringsRequestParams requestParams,
@@ -66,7 +66,7 @@ public class GatheringController {
                 getGatherings(requestParams, pageable));
     }
 
-    @Operation(summary = "모임 구성원목록 조회 [일반모임,  이벤트모임]")
+    @Operation(summary = "모임 구성원목록 조회 [일반모임, 이벤트모임]")
     @GetMapping("/{gathering_id}/members")
     public ResponseEntity<Slice<GatheringMemberResponse>> getGatheringMembers(
             @PathVariable("gathering_id") Long gatheringId,
@@ -101,13 +101,13 @@ public class GatheringController {
     }
 
 
-    @Operation(summary = " 모임 정상완료 체크 [일반모임]") // TODO: 이벤트 모임 정상완료 체크는 관리자가 하는 걸로 생각 중
+    @Operation(summary = " 모임 정상완료 체크 [일반모임, 이벤트모임]")
     @PostMapping("/{gathering_id}/completion")
     public ResponseEntity<Void> checkCompleteGathering(
             @PathVariable("gathering_id") Long gatheringId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        gatheringService.updateCompleteGeneralGathering(userDetails.getUserId(), gatheringId);
+        gatheringService.updateCompleteGathering(userDetails.getUserId(), gatheringId);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -88,7 +88,7 @@ public class GatheringController {
                         userDetails.getUserId(), gatheringId, requestList));
     }
 
-    @Operation(summary = " 모임 정상완료 체크 [일반모임]")
+    @Operation(summary = " 모임 정상완료 체크 [일반모임]") // TODO: 이벤트 모임 정상완료 체크는 관리자가 하는 걸로 생각 중
     @PostMapping("/{gathering_id}/completion")
     public ResponseEntity<Void> checkCompleteGathering(
             @PathVariable("gathering_id") Long gatheringId,

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -77,7 +77,7 @@ public class GatheringController {
     }
 
     @Operation(summary = "구성원 출석체크 [일반모임]")
-    @PostMapping("/{gathering_id}/members/attendance")
+    @PutMapping("/{gathering_id}/members/attendance")
     public ResponseEntity<List<MemberAttendanceStatusDto>> checkAttendanceGeneralGatheringMembers(
             @PathVariable("gathering_id") Long gatheringId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -89,7 +89,7 @@ public class GatheringController {
     }
 
     @Operation(summary = "구성원 출석체크 [이벤트 모임]")
-    @PostMapping("/{gathering_id}/event/members/attendance")
+    @PutMapping("/{gathering_id}/event/members/attendance")
     public ResponseEntity<AttendanceEventGatheringResponse> checkAttendanceEventGatheringMembers(
             @PathVariable("gathering_id") Long gatheringId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -102,7 +102,7 @@ public class GatheringController {
 
 
     @Operation(summary = " 모임 정상완료 체크 [일반모임, 이벤트모임]")
-    @PostMapping("/{gathering_id}/completion")
+    @PutMapping("/{gathering_id}/completion")
     public ResponseEntity<Void> checkCompleteGathering(
             @PathVariable("gathering_id") Long gatheringId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -78,7 +78,7 @@ public class GatheringController {
 
     @Operation(summary = "구성원 출석체크 [일반모임]")
     @PostMapping("/{gathering_id}/members/attendance")
-    public ResponseEntity<List<MemberAttendanceStatusDto>> checkAttendanceMembers(
+    public ResponseEntity<List<MemberAttendanceStatusDto>> checkAttendanceGeneralGatheringMembers(
             @PathVariable("gathering_id") Long gatheringId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody List<MemberAttendanceStatusDto> requestList) {
@@ -87,6 +87,19 @@ public class GatheringController {
                 gatheringService.checkAttendanceGeneralGatheringMembers(
                         userDetails.getUserId(), gatheringId, requestList));
     }
+
+    @Operation(summary = "구성원 출석체크 [이벤트 모임]")
+    @PostMapping("/{gathering_id}/event/members/attendance")
+    public ResponseEntity<AttendanceEventGatheringResponse> checkAttendanceEventGatheringMembers(
+            @PathVariable("gathering_id") Long gatheringId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody AttendanceEventGatheringRequest request) {
+
+        return ResponseEntity.ok(gatheringService.
+                checkAttendanceEventGatheringMembers(
+                        userDetails.getUserId(), gatheringId, request));
+    }
+
 
     @Operation(summary = " 모임 정상완료 체크 [일반모임]") // TODO: 이벤트 모임 정상완료 체크는 관리자가 하는 걸로 생각 중
     @PostMapping("/{gathering_id}/completion")

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -88,4 +88,15 @@ public class GatheringController {
                         userDetails.getUserId(), gatheringId, requestList));
     }
 
+    @Operation(summary = " 모임 정상완료 체크 [일반모임]")
+    @PostMapping("/{gathering_id}/completion")
+    public ResponseEntity<Void> checkCompleteGathering(
+            @PathVariable("gathering_id") Long gatheringId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        gatheringService.updateCompleteGeneralGathering(userDetails.getUserId(), gatheringId);
+
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -256,7 +256,7 @@ public class GatheringService {
             throw new GatheringException(INVALID_ATTENDANCE_CHECK_NOT_ORGANIZER);
         }
         if (EVENT.equals(gathering.getGatheringType())) {
-            throw new GatheringException(INVALID_ATTENDANCE_EVENT_GATHERING);
+            throw new GatheringException(INVALID_REQUEST_GATHERING_TYPE);
         }
         if (!NORMAL.equals(gathering.getStatus())) {
             throw new GatheringException(INVALID_ATTENDANCE_CHECK_NOT_NORMAL_GATHERING);

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -53,6 +53,8 @@ public class GatheringService {
     private final EventGatheringRepository eventGatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
 
+    private final EntityManager entityManager;
+
 
     // TODO: 만약 신고기능 구현하는거면 나중에 관련 로직 추가 필요
     // TODO: 날짜 설정 검증 로직 필요 (설정 날짜 관련 서비스 정책? 정하고 추후에 추가)
@@ -243,6 +245,8 @@ public class GatheringService {
                     .ifPresent(member -> member.checkAttendance(request.getStatus(), request.getRealDistance()));
         }
 
+        // TODO: Batch Update 적용
+        // 기본설정은 각 엔티티 마다 업데이트 쿼리를 1개씩 날림 (saveAll 을 한다고 쿼리문이 1개인 것이 아님)
         return gatheringMemberRepository.saveAll(members).stream()
                 .map(MemberAttendanceStatusDto::from).toList();
     }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface GatheringMemberRepository extends JpaRepository<GatheringMember, Long> {
+public interface GatheringMemberRepository extends JpaRepository<GatheringMember, Long>, GatheringMemberRepositoryCustom {
 
     @Query("select gm from GatheringMember gm " +
             " join fetch gm.user " +

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
@@ -8,12 +8,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface GatheringMemberRepository extends JpaRepository<GatheringMember, Long> {
 
     @Query("select gm from GatheringMember gm " +
             " join fetch gm.user " +
             " where gm.gathering.id = :gathering_id")
-    Slice<GatheringMember> findGatheringMembersByGatheringId(
+    Slice<GatheringMember> findGatheringMembersWithUserByGatheringId(
             @Param("gathering_id") Long gatheringId, Pageable pageable);
+
+    List<GatheringMember> findGatheringMembersByGatheringId(Long gatheringId);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.runto.domain.gathering.dao;
+
+import com.runto.domain.gathering.type.AttendanceStatus;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GatheringMemberRepositoryCustom {
+
+
+    long updateAttendanceAndDistance(Long gatheringId,
+                                     AttendanceStatus status,
+                                     Double realDistance,
+                                     List<Long> memberIds);
+}

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface GatheringMemberRepositoryCustom {
                                      AttendanceStatus status,
                                      Double realDistance,
                                      List<Long> memberIds);
+
+    Long countMembers(Long gatheringId, AttendanceStatus status);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustomImpl.java
@@ -1,0 +1,48 @@
+package com.runto.domain.gathering.dao;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.runto.domain.gathering.dto.QGatheringMember;
+import com.runto.domain.gathering.type.AttendanceStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.runto.domain.gathering.dto.QGatheringMember.*;
+import static com.runto.domain.gathering.type.AttendanceStatus.ATTENDING;
+
+@RequiredArgsConstructor
+@Repository
+public class GatheringMemberRepositoryCustomImpl implements GatheringMemberRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Transactional
+    @Override
+    public long updateAttendanceAndDistance(Long gatheringId,
+                                            AttendanceStatus status,
+                                            Double realDistance,
+                                            List<Long> memberIds) {
+
+        return jpaQueryFactory.update(gatheringMember)
+                .set(gatheringMember.attendanceStatus, status)
+                .set(gatheringMember.realDistance, realDistance)
+                .where(attendanceMemberCondition(status, memberIds),
+                        gatheringMember.gathering.id.eq(gatheringId))
+                .execute();
+    }
+
+    private BooleanExpression attendanceMemberCondition(AttendanceStatus status,
+                                                        List<Long> memberIds) {
+
+        if (ATTENDING.equals(status) && memberIds != null) {
+            return gatheringMember.id.in(memberIds);
+
+        } else {
+            return gatheringMember.attendanceStatus.ne(ATTENDING);
+        }
+    }
+
+}

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepositoryCustomImpl.java
@@ -2,7 +2,6 @@ package com.runto.domain.gathering.dao;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.runto.domain.gathering.dto.QGatheringMember;
 import com.runto.domain.gathering.type.AttendanceStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.runto.domain.gathering.dto.QGatheringMember.*;
+import static com.runto.domain.gathering.dto.QGatheringMember.gatheringMember;
 import static com.runto.domain.gathering.type.AttendanceStatus.ATTENDING;
 
 @RequiredArgsConstructor
@@ -26,12 +25,24 @@ public class GatheringMemberRepositoryCustomImpl implements GatheringMemberRepos
                                             Double realDistance,
                                             List<Long> memberIds) {
 
-        return jpaQueryFactory.update(gatheringMember)
+        return jpaQueryFactory
+                .update(gatheringMember)
                 .set(gatheringMember.attendanceStatus, status)
                 .set(gatheringMember.realDistance, realDistance)
                 .where(attendanceMemberCondition(status, memberIds),
                         gatheringMember.gathering.id.eq(gatheringId))
                 .execute();
+    }
+
+    @Override
+    public Long countMembers(Long gatheringId, AttendanceStatus status) {
+
+        return jpaQueryFactory
+                .select(gatheringMember.count())
+                .from(gatheringMember)
+                .where(gatheringMember.attendanceStatus.eq(status),
+                        gatheringMember.gathering.id.eq(gatheringId))
+                .fetchOne();
     }
 
     private BooleanExpression attendanceMemberCondition(AttendanceStatus status,

--- a/src/main/java/com/runto/domain/gathering/domain/Gathering.java
+++ b/src/main/java/com/runto/domain/gathering/domain/Gathering.java
@@ -80,6 +80,10 @@ public class Gathering extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private GatheringType gatheringType;
 
+    // TODO: 기존에 구현한 조회기능에 해당 필드에 대한 로직 추가
+    @Column(name = "is_normal_completed", nullable = false)
+    private Boolean isNormalCompleted;
+
     @JoinColumn(name = "event_gathering_id")
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private EventGathering eventGathering;
@@ -124,11 +128,16 @@ public class Gathering extends BaseTimeEntity {
         this.eventGathering = new EventGathering(this);
     }
 
+    public void checkNormalComplete() {
+        isNormalCompleted = true;
+    }
+
 
     @PrePersist
     public void prePersist() {
         hits = 0L;
         status = NORMAL;
+        isNormalCompleted = false;
         currentNumber = 1; // 주최자에 대한 수
     }
 

--- a/src/main/java/com/runto/domain/gathering/dto/AttendanceEventGatheringRequest.java
+++ b/src/main/java/com/runto/domain/gathering/dto/AttendanceEventGatheringRequest.java
@@ -1,0 +1,19 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AttendanceEventGatheringRequest { // 이벤트모임은 한번에 별개의 값으로 처리 불가하게 하였음
+
+    @NotNull(message = "real_distance 은 필수값입니다.")
+    private Double realDistance;
+
+    @NotNull(message = "member_id_list 는 필수값입니다.")
+    private List<Long> memberIdList;
+}

--- a/src/main/java/com/runto/domain/gathering/dto/AttendanceEventGatheringResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/AttendanceEventGatheringResponse.java
@@ -1,0 +1,17 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AttendanceEventGatheringResponse { // 수정될 수도 있음
+
+    private Double realDistance;
+    private long requestAttendingMemberCount;
+    private long updateAttendingMemberCount;
+    private long notAttendingMemberCount;
+}

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringMember.java
@@ -8,6 +8,8 @@ import com.runto.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import static com.runto.domain.gathering.type.AttendanceStatus.ATTENDING;
+
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,6 +46,20 @@ public class GatheringMember extends BaseTimeEntity {
                 .user(user)
                 .role(role)
                 .build();
+    }
+
+    public void checkAttendance(AttendanceStatus status, double realDistance) {
+
+        if (status != null) {
+            this.attendanceStatus = status;
+        } else {
+            return;
+        }
+
+        if (ATTENDING.equals(status)) {
+            this.realDistance = realDistance;
+        }
+
     }
 
     @PrePersist

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringMemberResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringMemberResponse.java
@@ -2,13 +2,12 @@ package com.runto.domain.gathering.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.type.AttendanceStatus;
 import com.runto.domain.gathering.type.GatheringMemberRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Builder
 @AllArgsConstructor
@@ -17,10 +16,13 @@ import java.util.List;
 @Getter
 public class GatheringMemberResponse {
 
-    private Long gatheringMemberId;
+    private Long memberId;
+    private Long memberAccountId;
     private String nickname;
     private String profileImageUrl;
     private GatheringMemberRole role;
+    private AttendanceStatus attendanceStatus;
+    private Double realDistance;
 
 //    public static List<GatheringMemberResponse> from(List<GatheringMember> gatheringMembers) {
 //
@@ -32,10 +34,13 @@ public class GatheringMemberResponse {
     public static GatheringMemberResponse from(GatheringMember gatheringMember) {
 
         return GatheringMemberResponse.builder()
-                .gatheringMemberId(gatheringMember.getId())
+                .memberId(gatheringMember.getId())
+                .memberAccountId(gatheringMember.getUser().getId())
                 .nickname(gatheringMember.getUser().getNickname())
                 .profileImageUrl(gatheringMember.getUser().getProfileImageUrl())
                 .role(gatheringMember.getRole())
+                .attendanceStatus(gatheringMember.getAttendanceStatus())
+                .realDistance(gatheringMember.getRealDistance())
                 .build();
     }
 

--- a/src/main/java/com/runto/domain/gathering/dto/MemberAttendanceStatusDto.java
+++ b/src/main/java/com/runto/domain/gathering/dto/MemberAttendanceStatusDto.java
@@ -1,0 +1,41 @@
+package com.runto.domain.gathering.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.runto.domain.gathering.type.AttendanceStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class MemberAttendanceStatusDto { // 요청값, 반환값
+
+    @NotNull
+    private Long memberId;
+
+    @NotNull
+    private Long memberAccountId;
+
+    @NotNull
+    private AttendanceStatus status;
+
+    @NotNull
+    private Double realDistance;
+
+
+    public static MemberAttendanceStatusDto from(GatheringMember member) {
+
+        return MemberAttendanceStatusDto.builder()
+                .memberId(member.getId())
+                .memberAccountId(member.getUser().getId())
+                .status(member.getAttendanceStatus())
+                .realDistance(member.getRealDistance())
+                .build();
+    }
+}

--- a/src/main/java/com/runto/domain/gathering/type/AttendanceStatus.java
+++ b/src/main/java/com/runto/domain/gathering/type/AttendanceStatus.java
@@ -1,5 +1,8 @@
 package com.runto.domain.gathering.type;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum AttendanceStatus {
 
     ATTENDING,   // 참석

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -23,13 +23,11 @@ public enum ErrorCode {
     INVALID_ATTENDANCE_CHECK_NOT_NORMAL_GATHERING(FORBIDDEN,"NORMAL 상태가 아닌 모임은 출석체크 할 수 없습니다."),
     INVALID_ATTENDANCE_BEFORE_MEETING(FORBIDDEN, "모임 날짜/시간 전에는 출석체크 할 수 없습니다."),
     INVALID_ATTENDANCE_AFTER_ONE_WEEK(FORBIDDEN, "모임 날짜로부터 일주일이 지난 후에는 출석체크 할 수 없습니다."),
-    INVALID_ATTENDANCE_EVENT_GATHERING(BAD_REQUEST, "이벤트 모임은 출석체크를 할 수 없습니다."),
     INVALID_COMPLETE_GATHERING_NOT_ORGANIZER(FORBIDDEN, "모임의 주최자가 아니면 완료시킬 수 없습니다."),
     INVALID_COMPLETE_GATHERING_NOT_NORMAL_GATHERING(FORBIDDEN, "NORMAL 상태가 아닌 모임은 정상완료 할 수 없습니다."),
     INVALID_COMPLETE_GATHERING_BEFORE_MEETING(FORBIDDEN, "모임 날짜/시간 전에는 정상완료할 수 없습니다."),
     INVALID_COMPLETE_AFTER_ONE_WEEK(FORBIDDEN, "모임 날짜로부터 일주일이 지난 후에는 정상완료 할 수 없습니다."),
     INVALID_COMPLETE_UNCHECKED_MEMBERS(FORBIDDEN,"출석체크하지 않은 멤버가 있으면 정상완료를 할 수 없습니다."),
-    INVALID_COMPLETE_EVENT_GENERAL_USER(FORBIDDEN,"이벤트 모임은 일반회원이 정상완료시킬 수 없습니다."),
     INVALID_REQUEST_GATHERING_TYPE(BAD_REQUEST,"해당 모임에 맞지 않는 요청입니다."),
     ALREADY_NORMAL_COMPLETE_GATHERING(FORBIDDEN, "이미 정상완료한 모임입니다."),
 

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -16,9 +16,14 @@ public enum ErrorCode {
     // 모임글 & 이벤트 관련
     GATHERING_NOT_FOUND(NOT_FOUND, "존재하지 않는 모임글입니다."),
     GATHERING_REPORTED(FORBIDDEN, "신고당한 모임글입니다."),
-    EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW(FORBIDDEN,"승인상태가 아닌 이벤트모임은 주최자 본인만 볼 수 있습니다."),
+    EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW(FORBIDDEN, "승인상태가 아닌 이벤트모임은 주최자 본인만 볼 수 있습니다."),
     GENERAL_MAX_NUMBER(BAD_REQUEST, "일반 모임의 최대 인원은 2명에서 10명 사이여야 합니다."),
     EVENT_GATHERING_MAX_NUMBER(BAD_REQUEST, "이벤트 모임의 최대 인원은 10명에서 300명 사이여야 합니다."),
+    INVALID_ATTENDANCE_CHECK_NOT_ORGANIZER(FORBIDDEN, "모임의 주최자가 아니면 출석체크 할 수 없습니다."),
+    INVALID_ATTENDANCE_CHECK_NOT_NORMAL_GATHERING(FORBIDDEN,"NORMAL 상태가 아닌 모임은 출석체크 할 수 없습니다."),
+    INVALID_ATTENDANCE_BEFORE_MEETING(FORBIDDEN, "모임 날짜/시간 전에는 출석체크 할 수 없습니다."),
+    INVALID_ATTENDANCE_AFTER_ONE_WEEK(FORBIDDEN, "모임 날짜로부터 일주일이 지난 후에는 출석체크 할 수 없습니다."),
+    INVALID_ATTENDANCE_EVENT_GATHERING(BAD_REQUEST, "이벤트 모임은 출석체크를 할 수 없습니다."),
 
 
     // 채팅관련,

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     INVALID_COMPLETE_AFTER_ONE_WEEK(FORBIDDEN, "모임 날짜로부터 일주일이 지난 후에는 정상완료 할 수 없습니다."),
     INVALID_COMPLETE_UNCHECKED_MEMBERS(FORBIDDEN,"출석체크하지 않은 멤버가 있으면 정상완료를 할 수 없습니다."),
     INVALID_COMPLETE_EVENT_GENERAL_USER(FORBIDDEN,"이벤트 모임은 일반회원이 정상완료시킬 수 없습니다."),
-
+    INVALID_REQUEST_GATHERING_TYPE(BAD_REQUEST,"해당 모임에 맞지 않는 요청입니다."),
 
     // 채팅관련,
     CHATROOM_ALREADY_EXIST(CONFLICT, "이미 존재하는 채팅방입니다."),

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -24,6 +24,12 @@ public enum ErrorCode {
     INVALID_ATTENDANCE_BEFORE_MEETING(FORBIDDEN, "모임 날짜/시간 전에는 출석체크 할 수 없습니다."),
     INVALID_ATTENDANCE_AFTER_ONE_WEEK(FORBIDDEN, "모임 날짜로부터 일주일이 지난 후에는 출석체크 할 수 없습니다."),
     INVALID_ATTENDANCE_EVENT_GATHERING(BAD_REQUEST, "이벤트 모임은 출석체크를 할 수 없습니다."),
+    INVALID_COMPLETE_GATHERING_NOT_ORGANIZER(FORBIDDEN, "모임의 주최자가 아니면 완료시킬 수 없습니다."),
+    INVALID_COMPLETE_GATHERING_NOT_NORMAL_GATHERING(FORBIDDEN, "NORMAL 상태가 아닌 모임은 정상완료 할 수 없습니다."),
+    INVALID_COMPLETE_GATHERING_BEFORE_MEETING(FORBIDDEN, "모임 날짜/시간 전에는 정상완료할 수 없습니다."),
+    INVALID_COMPLETE_AFTER_ONE_WEEK(FORBIDDEN, "모임 날짜로부터 일주일이 지난 후에는 정상완료 할 수 없습니다."),
+    INVALID_COMPLETE_UNCHECKED_MEMBERS(FORBIDDEN,"출석체크하지 않은 멤버가 있으면 정상완료를 할 수 없습니다."),
+    INVALID_COMPLETE_EVENT_GENERAL_USER(FORBIDDEN,"이벤트 모임은 일반회원이 정상완료시킬 수 없습니다."),
 
 
     // 채팅관련,

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     INVALID_COMPLETE_UNCHECKED_MEMBERS(FORBIDDEN,"출석체크하지 않은 멤버가 있으면 정상완료를 할 수 없습니다."),
     INVALID_COMPLETE_EVENT_GENERAL_USER(FORBIDDEN,"이벤트 모임은 일반회원이 정상완료시킬 수 없습니다."),
     INVALID_REQUEST_GATHERING_TYPE(BAD_REQUEST,"해당 모임에 맞지 않는 요청입니다."),
+    ALREADY_NORMAL_COMPLETE_GATHERING(FORBIDDEN, "이미 정상완료한 모임입니다."),
 
     // 채팅관련,
     CHATROOM_ALREADY_EXIST(CONFLICT, "이미 존재하는 채팅방입니다."),


### PR DESCRIPTION
## 🔎 작업 내용

### 일반모임 출석체크

각 멤버에 대해 실제 뛴 거리, 참가, 불참을 체크할 수 있다. 
한 요청에서 모든 멤버에 대해 요청한다. (최대 10명)

```
[
    {
        "member_id": 1,
        "member_account_id": 64,
        "status": "ATTENDING",
        "real_distance": 10.2
    },
    {
        "member_id": 2,
        "member_account_id": 66,
        "status": "NOT_ATTENDING",
        "real_distance": 0.0
    },
    {
        "member_id": 3,
        "member_account_id": 68,
        "status": "ATTENDING",
        "real_distance": 1.0
    },
    {
        "member_id": 4,
        "member_account_id": 70,
        "status": "NOT_ATTENDING",
        "real_distance": 0.0
    },
    {
        "member_id": 5,
        "member_account_id": 72,
        "status": "NOT_ATTENDING",
        "real_distance": 0.0
    }
]
```
###  이벤트모임 출석체크

일반모임과는 달리 개별의 값을 요청할 수 없다. (구성원 수가 훨씬 많아서 방식을 달리하였음)
member_id_list 로 보내온 memberId 에 속한 구성원들을
 참가 상태로 변경, 실제 뛴 거리로 업데이트 후 ->  참가 상태가 아닌 멤버들을 일괄 불참 상태로 업데이트한다.
(요청값으로 해당모임에 속하지 않은 구성원의 아이디를 보내더라도, 쿼리 조건문에서 걸러짐)
```
{
  "real_distance": 123.45,
  "member_id_list": [1,3,4,16,19]
}

```

### 정상완료 체크(일반, 이벤트)

출석체크 자체가 되지 않은 구성원이 있다면 정상완료 체크 불가
(다른 검증로직에 대해서는 설명 생략)



<br/>
closed: #89 