### PR TITLE
✨Feat(#96): 내 프로필사진 수정 기능 구현

### DIFF
--- a/src/main/java/com/runto/domain/admin/application/AdminService.java
+++ b/src/main/java/com/runto/domain/admin/application/AdminService.java
@@ -56,7 +56,7 @@ public class AdminService {
     public void releaseUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(
                 ()-> new UserException(ErrorCode.USER_NOT_FOUND));
-        user.releaseUser(user);
+        user.releaseUser();
     }
 
     public List<GatheringCountResponse> manageGathering(AdminGatherStatsCount statsCount) {

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -126,7 +126,7 @@ public class GatheringService {
         if (imageUrlDto == null) return;
 
         List<GatheringImage> gatheringImages = imageUrlDto.getContentImageUrls().stream()
-                .map(ImageUrlDto::toEntity)
+                .map(ImageUrlDto::toGathering)
                 .toList();
         gathering.addContentImages(gatheringImages);
     }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustomImpl.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import static com.querydsl.core.types.ConstantImpl.create;
 import static com.querydsl.core.types.dsl.MathExpressions.*;
-import static com.runto.domain.common.SortUtil.getOrderSpecifier;
+import static com.runto.global.utils.SortUtils.getOrderSpecifier;
 import static com.runto.domain.gathering.domain.QEventGathering.eventGathering;
 import static com.runto.domain.gathering.domain.QGathering.gathering;
 import static com.runto.domain.gathering.dto.QGatheringMember.gatheringMember;

--- a/src/main/java/com/runto/domain/image/api/ImageController.java
+++ b/src/main/java/com/runto/domain/image/api/ImageController.java
@@ -4,6 +4,7 @@ import com.runto.domain.image.application.ImageService;
 import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUploadRequest;
 import com.runto.domain.image.type.ImageUrlsResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +19,8 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @PostMapping("/gathering")
+    @Operation(summary = "모임글 이미지 등록 (1~3개 가능)")
+    @PostMapping("/gatherings")
     public ResponseEntity<ImageRegisterResponse> registerGatheringImages(
             @RequestPart(value = "representative_image_index", required = false) Integer representativeImageIndex,
             @RequestPart(value = "images", required = false) List<MultipartFile> images,
@@ -28,6 +30,7 @@ public class ImageController {
                 ImageUploadRequest.of(representativeImageIndex, images, imageOrder)));
     }
 
+    @Operation(summary = "모임글 이미지주소 목록 가져오기 (모임글 상세조회에 사용)")
     @GetMapping
     public ResponseEntity<ImageUrlsResponse> getGatheringImages(
             @RequestParam("gathering_id") Long gatheringId) {

--- a/src/main/java/com/runto/domain/image/application/ImageService.java
+++ b/src/main/java/com/runto/domain/image/application/ImageService.java
@@ -1,12 +1,11 @@
 package com.runto.domain.image.application;
 
 import com.runto.domain.image.dao.GatheringImageRepository;
-import com.runto.domain.image.dto.ImageRegisterResponse;
-import com.runto.domain.image.dto.ImageUploadRequest;
-import com.runto.domain.image.dto.ImageUrlDto;
+import com.runto.domain.image.dto.*;
 import com.runto.domain.image.type.ImageUrlsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -14,15 +13,15 @@ import java.util.List;
 @Service
 public class ImageService {
 
-    private final S3GatheringImageService s3GatheringImageService;
+    private final S3ImageService s3ImageService;
     private final GatheringImageRepository gatheringImageRepository;
 
     public ImageRegisterResponse registerGatheringImages(ImageUploadRequest uploadRequest) {
 
         if (uploadRequest == null) return null;
 
-        List<ImageUrlDto> contentImageUrls = s3GatheringImageService
-                .uploadContentImages(uploadRequest.getImages());
+        List<ImageUrlDto> contentImageUrls = s3ImageService
+                .uploadContentImages(uploadRequest.getImages(), "gathering");
 
         return ImageRegisterResponse.of(
                 uploadRequest.getRepresentativeImageIndex(), contentImageUrls);
@@ -33,7 +32,7 @@ public class ImageService {
         if (contentImageUrls == null || contentImageUrls.isEmpty()) return;
 
         contentImageUrls.forEach(imageUrlDto ->
-                s3GatheringImageService.moveImageProcess(imageUrlDto.getImageUrl()));
+                s3ImageService.moveImageProcess(imageUrlDto.getImageUrl()));
     }
 
     public ImageUrlsResponse getGatheringImages(Long gatheringId) {
@@ -44,4 +43,17 @@ public class ImageService {
                         .toList());
     }
 
+
+    public ImageUrlDto updateUserProfile(Long userId, MultipartFile newImageFile, String oldImageUrl) {
+
+        s3ImageService.deleteS3Object(oldImageUrl, "temp/"); // TODO 나중에 이미지 버그 수정 및 리팩토링 때 수정될 수도 있음
+
+        if (newImageFile == null || newImageFile.isEmpty()) {
+            return new ImageUrlDto(null, 0);
+        }
+
+        return s3ImageService.uploadContentImages(
+                List.of(new ImageDto(newImageFile, 0)),
+                        String.format("profile[%s]", userId)).get(0);
+    }
 }

--- a/src/main/java/com/runto/domain/image/dto/ImageUrlDto.java
+++ b/src/main/java/com/runto/domain/image/dto/ImageUrlDto.java
@@ -28,7 +28,7 @@ public class ImageUrlDto {
                 .build();
     }
 
-    public GatheringImage toEntity() {
+    public GatheringImage toGathering() { // Gathering 외에도 쓰게돼서 엔티티이름으로 바꿈
         return GatheringImage.builder()
                 .imageUrl(imageUrl)
                 .imageOrder(order)

--- a/src/main/java/com/runto/domain/user/api/UserController.java
+++ b/src/main/java/com/runto/domain/user/api/UserController.java
@@ -4,6 +4,7 @@ import com.runto.domain.gathering.application.GatheringService;
 import com.runto.domain.gathering.dto.UserEventGatheringsResponse;
 import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
 import com.runto.domain.gathering.dto.UserGatheringsResponse;
+import com.runto.domain.image.dto.ImageUrlDto;
 import com.runto.domain.user.application.UserService;
 import com.runto.domain.user.dto.*;
 import com.runto.global.security.detail.CustomUserDetails;
@@ -16,6 +17,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/users")
@@ -81,7 +83,7 @@ public class UserController {
     }
 
     @Operation(summary = "내 닉네임 수정")
-    @PatchMapping("/nickname")
+    @PatchMapping("/profile-nickname")
     public ResponseEntity<Void> updateMyNickname(
             @Valid @RequestBody NicknameRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -90,6 +92,17 @@ public class UserController {
         return ResponseEntity.ok().build();
 
     }
+
+    @Operation(summary = "내 프로필사진 수정")
+    @PatchMapping("/profile-image")
+    public ResponseEntity<ImageUrlDto> updateMyProfileImage(
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return ResponseEntity.ok(userService.
+                updateUserProfile(userDetails.getUserId(), image));
+    }
+
     //TODO 회원탈퇴
     //1) 탈퇴한 회원테이블 따로 만들기 이메일중복방지
     //2) 탈퇴 시 이메일 더미이메일로 교체? (별로선호하지않으나 쉬울듯.)

--- a/src/main/java/com/runto/domain/user/domain/User.java
+++ b/src/main/java/com/runto/domain/user/domain/User.java
@@ -74,12 +74,7 @@ public class User extends BaseTimeEntity {
         return user;
     }
 
-    @PrePersist
-    public void prePersist() {
-        status = UserStatus.ACTIVE;
-    }
-
-    public void releaseUser(User user) {
+    public void releaseUser() {
         this.status = UserStatus.ACTIVE;
     }
 
@@ -90,5 +85,15 @@ public class User extends BaseTimeEntity {
         }
         this.nickname = nickname;
     }
+
+    public void updateProfile(String profileUrl) {
+        this.profileImageUrl = profileUrl;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        status = UserStatus.ACTIVE;
+    }
+
 
 }

--- a/src/main/java/com/runto/global/utils/SortUtils.java
+++ b/src/main/java/com/runto/global/utils/SortUtils.java
@@ -1,14 +1,11 @@
-package com.runto.domain.common;
+package com.runto.global.utils;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
-import java.util.List;
-
-public class SortUtil {
+public class SortUtils {
 
     /**
      *


### PR DESCRIPTION
## 🔎 작업 내용

### 내 프로필 사진 수정 기능

1. MultipartFile 를 1개를 받아서 요청 (보내지 않을 시 기존의 프로필 이미지를 삭제)
2. 인증객체에서 추출한 userId를 통해 User 엔티티를 가져온다.
3. User 엔티티에 있는 프로필이미지 url을 가져온다. (기존 이미지)
4.   s3 에 저장돼있는 기존의 이미지를 삭제 
5.  새롭게 요청한 이미지를 s3에 업로드 후 url 반환 (MultipartFile 을 보내오지 않았다면 null 반환)
6.  반환받은 값을 user 엔티티의 프로필 이미지로 수정한다.

 관련 dto , s3이미지 서비스 의 경우 기존의 ``모임글 업로드 기능`` #23 구현 때 만들었던 걸 같이 사용하는 방식으로 진행했습니다. 

커밋된 건 얼마 없는데, 
기존에 구현했던 s3이미지 서비스를 어떤 식으로 같이 사용해야할까 에서 고민을 하면서 이것저것 수정해보다가
시간이 생각보다 많이 걸렸네요.
결국은 마지막 결과는 기존에서 수정된 건 거의 없다는게 하하..😂 
