### PR TITLE
♻️Refactor(GATHERING): CreateGatheringRequest - GatheringType 필드 삭제, …

### DIFF
--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -56,7 +56,6 @@ public class GatheringService {
     private final EventGatheringRepository eventGatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
 
-    private final EntityManager entityManager;
 
 
     // TODO: 만약 신고기능 구현하는거면 나중에 관련 로직 추가 필요
@@ -65,8 +64,8 @@ public class GatheringService {
     @Transactional
     public void createGatheringGeneral(Long userId, CreateGatheringRequest request) {
 
-        validateMaxNumber(request.getGatheringType(), request.getMaxNumber());
-        gatheringRepository.save(createGathering(userId, request));
+        validateMaxNumber(GENERAL, request.getMaxNumber());
+        gatheringRepository.save(createGathering(userId, request,GENERAL));
 
         // s3 temp 경로에 있던 이미지파일들을 정식 경로에 옮기기
 //        imageService.moveImageFromTempToPermanent(request.getGatheringImageUrls()
@@ -78,9 +77,9 @@ public class GatheringService {
     public void requestEventGatheringHosting(Long userId,
                                              CreateGatheringRequest request) {
 
-        validateMaxNumber(request.getGatheringType(), request.getMaxNumber());
+        validateMaxNumber(EVENT, request.getMaxNumber());
 
-        Gathering gathering = createGathering(userId, request);
+        Gathering gathering = createGathering(userId, request,EVENT);
         gathering.applyForEvent(); // 해당 모임을 이벤트모임으로 신청
         gatheringRepository.save(gathering);
 
@@ -90,14 +89,14 @@ public class GatheringService {
 
     }
 
-    private Gathering createGathering(Long userId, CreateGatheringRequest request) {
+    private Gathering createGathering(Long userId, CreateGatheringRequest request, GatheringType type) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         validateDate(request.getDeadline(), request.getAppointedAt());
 
-        Gathering gathering = request.toEntity(user);
+        Gathering gathering = request.toEntity(user, type);
         gathering.addMember(user, ORGANIZER);
         addContentImages(request.getImageRegisterResponse(), gathering);
 

--- a/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
+++ b/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
@@ -16,6 +16,10 @@ import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDateTime;
 
+// 등록 api 를 분리하면서 요청값에서 GatheringType 값을 삭제하였음
+// request 의 type 값을 받아서 Gathering 을 생성하던 상황 -> 일반모임생성인데 이벤트를 요청값에 넣어서 이벤트타입의 모임글로 생성될 수 있었음
+// 예외처리보다는 type 값 자체를 받지 않는 방식을 택하였음
+
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateGatheringRequest {
@@ -46,15 +50,13 @@ public class CreateGatheringRequest {
 
     @NotNull(message = "목표 km 를 설정해야합니다.")
     private RunningConcept concept;
-
-    @NotNull(message = "모임 타입은 필수값입니다.")
-    private GatheringType gatheringType;
+    
 
     @Valid
     private ImageRegisterResponse imageRegisterResponse;
 
 
-    public Gathering toEntity(User organizer) {
+    public Gathering toEntity(User organizer, GatheringType type) {
 
         return Gathering.builder()
                 .organizerId(organizer.getId())
@@ -67,7 +69,7 @@ public class CreateGatheringRequest {
                 .thumbnailUrl(imageRegisterResponse.getRepresentativeImageUrl())
                 .location(location.toLocation())
                 .maxNumber(maxNumber)
-                .gatheringType(gatheringType)
+                .gatheringType(type)
                 .build();
     }
 }


### PR DESCRIPTION
…toEntity 수정, 등록 서비스 로직 수정

등록 api 를 분리하면서 요청값에서 GatheringType 값을 삭제하였음
request 의 type 값을 받아서 Gathering 을 생성하던 상황 -> 일반모임생성인데 이벤트를 요청값에 넣어서 이벤트타입의 모임글로 생성될 수 있었음 예외처리보다는 type 값 자체를 받지 않는 방식을 택하였음

related: #103

- 제목 : feat(#issue 번호): 기능명
  ex) # feat(#17): pull request template 작성
  (확인 후 지워주세요)
  
  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요

  <br/>

## 이미지 첨부 (선)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<br/>
