### PR TITLE
:recycle: Feat(#65): cookie세팅변경

### DIFF
--- a/src/main/java/com/runto/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/runto/global/security/filter/JwtFilter.java
@@ -31,8 +31,8 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        String accessToken = Optional.ofNullable(jwtUtil.extractAccessToken(request))
-                .orElse(jwtUtil.oauthAccessToken(request));
+        String accessToken = jwtUtil.extractAccessToken(request);
+//                .orElse(jwtUtil.oauthAccessToken(request));
 
         if(accessToken == null) {
             System.out.println("Authorization header is missing");

--- a/src/main/java/com/runto/global/security/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/runto/global/security/oauth2/CustomSuccessHandler.java
@@ -42,10 +42,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         //OAuth2에서는 요청 특성상 응답 헤더로 받을 수 없습니다. 따라서 쿠키 방식으로 받으셔야 합니다.
         log.info(token);
         response.setContentType("application/json");
-        ResponseCookie cookie = ResponseCookie.from("Authorization", token)
+        ResponseCookie cookie = ResponseCookie.from("Authorization","Bearer "+token)
                 .path("/")
                 .sameSite("None")
-                .httpOnly(true)
+                .httpOnly(false)
                 .domain("myspringserver.store") // 예시입니다! 서버의 도메인만 적어주면 됨
                 .secure(true) // sameSite를 None으로 지정했다면 필수
                 .build();

--- a/src/main/java/com/runto/global/security/util/JWTUtil.java
+++ b/src/main/java/com/runto/global/security/util/JWTUtil.java
@@ -53,17 +53,17 @@ public class JWTUtil {
         }
         return null;
     }
-    public String oauthAccessToken(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            return null;
-        }
-        for (Cookie cookie : cookies) {
-            System.out.println(cookie.getName());
-            if (cookie.getName().equals("Authorization")) {
-                return cookie.getValue();
-            }
-        }
-        return null;
-    }
+//    public String oauthAccessToken(HttpServletRequest request) {
+//        Cookie[] cookies = request.getCookies();
+//        if (cookies == null) {
+//            return null;
+//        }
+//        for (Cookie cookie : cookies) {
+//            System.out.println(cookie.getName());
+//            if (cookie.getName().equals("Authorization")) {
+//                return cookie.getValue();
+//            }
+//        }
+//        return null;
+//    }
 }

--- a/src/main/java/com/runto/global/security/util/RefreshUtil.java
+++ b/src/main/java/com/runto/global/security/util/RefreshUtil.java
@@ -28,7 +28,7 @@ public class RefreshUtil {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24*60*60*1000);
         cookie.setSecure(true);
-        cookie.setHttpOnly(true);
+        cookie.setHttpOnly(false);
 
         return cookie;
     }


### PR DESCRIPTION
   <br/>

## 🔎 작업 내용

- cookie세팅변경
-   .httpOnly(true) -> .httpOnly(false) 
  <br/>

## 이미지 첨부 (선)


<br/>

## 🔧 리뷰 요구사항

 .httpOnly(true)로 설정 시 javascript를 통해 조회 불가하여 브라우저에서는 쿠키를 확인할 수 있으나 
js로 로컬스토리지에 보관할 수 없음

참고사항.
로그인 성공 쿠키로 발급
프론트의 특정 페이지로 리디렉션을 보냄
프론트의 특정 페이지는 axios를 통해 쿠키를(credentials=true)를 가지고 다시 백엔드로 접근하여 헤더로 토큰을 받아옴
헤더로 받아온 토큰을 로컬 스토리지등에 보관하여 사용


<br/>
