### PR TITLE
♻️ Feat(#65): cookie세팅변경

### DIFF
--- a/src/main/java/com/runto/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/runto/global/security/filter/JwtFilter.java
@@ -31,8 +31,8 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        String accessToken = jwtUtil.extractAccessToken(request);
-//                .orElse(jwtUtil.oauthAccessToken(request));
+        String accessToken = Optional.ofNullable(jwtUtil.extractAccessToken(request))
+                .orElse(jwtUtil.oauthAccessToken(request));
 
         if(accessToken == null) {
             System.out.println("Authorization header is missing");

--- a/src/main/java/com/runto/global/security/filter/ReissueFilter.java
+++ b/src/main/java/com/runto/global/security/filter/ReissueFilter.java
@@ -82,7 +82,7 @@ public class ReissueFilter extends OncePerRequestFilter {
         refreshRepository.deleteByRefresh(refresh);
         refreshUtil.addRefreshEntity(username, newRefresh, 3*24*60*60*1000L);
 
-        response.setHeader("Authorization", newAccess);
+        response.setHeader("Authorization", "Bearer "+newAccess);
         response.addCookie(refreshUtil.createCookie("refresh", newRefresh));
     /*
     Rotate 되기 이전의 토큰을 가지고 서버측으로 가도 인증이 되기 때문에 서버측에서 발급했던

--- a/src/main/java/com/runto/global/security/util/JWTUtil.java
+++ b/src/main/java/com/runto/global/security/util/JWTUtil.java
@@ -53,17 +53,17 @@ public class JWTUtil {
         }
         return null;
     }
-//    public String oauthAccessToken(HttpServletRequest request) {
-//        Cookie[] cookies = request.getCookies();
-//        if (cookies == null) {
-//            return null;
-//        }
-//        for (Cookie cookie : cookies) {
-//            System.out.println(cookie.getName());
-//            if (cookie.getName().equals("Authorization")) {
-//                return cookie.getValue();
-//            }
-//        }
-//        return null;
-//    }
+    public String oauthAccessToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            System.out.println(cookie.getName());
+            if (cookie.getName().equals("Authorization")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
 <br/>

## 🔎 작업 내용

- 결국 롤백 했습니다.

  <br/>

## 이미지 첨부 (선)


<br/>

## 🔧 리뷰 요구사항

 httponly false를 해도 리액트에서는 접근하지 못했습니다.

그래도 소셜로그인과 로컬로그인이 잘 되고있는것을 확인했습니다.

소셜로그인은 쿠키에 토큰이 담겨서 요청마다 인증을 하고 있고

로컬로그인은 헤더로 보낸 것을 로컬스토리지로 저장하여 요청마다 헤더로 인증 하고있습니다.

<br/>
