### PR TITLE
✅Refactor(#110): 모임 상세조회 리팩토링 (모임 참가/취소 구현 전 밑작업)

### DIFF
--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -124,4 +124,20 @@ public class GatheringController {
         return ResponseEntity.ok().build();
     }
 
+//    @PostMapping("/{gathering_id}/participation")
+//    public ResponseEntity<Void> participateGathering(@PathVariable("gathering_id") Long gatheringId,
+//                                                     @AuthenticationPrincipal CustomUserDetails userDetails) {
+//
+//        gatheringService.participateGathering(userDetails.getUserId(), gatheringId);
+//
+//        return ResponseEntity.ok().build();
+//    }
+//
+//    @DeleteMapping("/{gathering_id}/participation")
+//    public void cancelParticipateGathering(@PathVariable("gathering_id") Long gatheringId,
+//                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+//
+//
+//    }
+
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -357,4 +357,9 @@ public class GatheringService {
 
         return GatheringsMapResponse.of(radiusDistance, x, y, generalGatheringMap);
     }
+
+//    @Transactional
+//    public void participateGathering(Long userId, Long gatheringId) {
+//
+//    }
 }

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -4,10 +4,10 @@ package com.runto.domain.gathering.application;
 import com.runto.domain.gathering.dao.EventGatheringRepository;
 import com.runto.domain.gathering.dao.GatheringMemberRepository;
 import com.runto.domain.gathering.dao.GatheringRepository;
-import com.runto.domain.gathering.domain.EventGathering;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.dto.*;
 import com.runto.domain.gathering.exception.GatheringException;
+import com.runto.domain.gathering.type.EventRequestStatus;
 import com.runto.domain.gathering.type.GatheringStatus;
 import com.runto.domain.gathering.type.GatheringType;
 import com.runto.domain.image.application.ImageService;
@@ -18,8 +18,6 @@ import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.User;
 import com.runto.domain.user.dto.UserCalenderResponse;
 import com.runto.domain.user.excepction.UserException;
-import com.runto.global.exception.ErrorCode;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -145,19 +143,24 @@ public class GatheringService {
         gathering.addContentImages(gatheringImages);
     }
 
+
+    // 왜 dto 로 바로 받는 방식으로 수정했는지는 pr 참고 (관련이슈 #110)
     public GatheringDetailResponse getGatheringDetail(Long userId, Long gatheringId) {
 
-        Gathering gathering = gatheringRepository.findGatheringById(gatheringId)
-                .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
 
-        checkGatheringAccessibility(userId, gathering);
-        return GatheringDetailResponse.fromGathering(gathering);
+        GatheringDetailResponse response = gatheringRepository
+                .getGatheringDetailWithUserParticipation(gatheringId, userId);
+
+        validateGatheringAccessibility(userId, response);
+        return response;
 
     }
 
-    private void checkGatheringAccessibility(Long userId, Gathering gathering) {
+    private void validateGatheringAccessibility(Long userId, GatheringDetailResponse response) {
 
-        boolean isOrganizer = Objects.equals(gathering.getOrganizerId(), userId);
+        GatheringDetailContentResponse gathering = response.getContent();
+
+        boolean isOrganizer = Objects.equals(response.getOrganizerId(), userId);
         GatheringStatus status = gathering.getStatus();
 
         if (DELETED.equals(status)) {
@@ -170,16 +173,24 @@ public class GatheringService {
         }
 
         // 승인되지 않은 이벤트모임은 주최자가 아니면 볼 수 없음
-        if (EVENT.equals(gathering.getGatheringType()) && // 이벤트인지 검증하는 조건이 무조건 먼저 들어가야함
-                !isApprovedEventForNonOrganizer(gathering.getEventGathering(), isOrganizer)) {
+        if (EVENT.equals(gathering.getType()) &&
+                !isApprovedEventForNonOrganizer(gathering.getEventRequestStatus(), isOrganizer)) {
             throw new GatheringException(EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW);
         }
     }
 
-    private boolean isApprovedEventForNonOrganizer(EventGathering eventGathering, boolean isOrganizer) {
+    private boolean isApprovedEventForNonOrganizer(EventRequestStatus eventRequestStatus,
+                                                   boolean isOrganizer) {
 
+        // dto로 받기로 해서 필요 없어짐
+        // Gathering 의 타입이 Event 이지만, 이벤트에 관한 데이터가 없을 수도 있는 상황 대비
+        if (eventRequestStatus == null) {
+            throw new GatheringException(EVENT_GATHERING_NOT_FOUND);
+        }
+
+        // 승인되지 않은 이벤트는 주최자 외에는 조회 불가
         if (!isOrganizer) {
-            return APPROVED.equals(eventGathering.getStatus());
+            return APPROVED.equals(eventRequestStatus);
         }
         return true;
     }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
@@ -4,17 +4,10 @@ package com.runto.domain.gathering.dao;
 import com.runto.domain.admin.dao.GatheringMgmtRepositoryCustom;
 import com.runto.domain.gathering.domain.Gathering;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringRepositoryCustom, GatheringMgmtRepositoryCustom {
 
-    @Query("select g from Gathering g " +
-            " left join fetch g.eventGathering " +
-            " where g.id= :gathering_id ")
-    Optional<Gathering> findGatheringById(@Param("gathering_id") Long gatheringId);
+
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.runto.domain.gathering.dao;
 
 import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.gathering.dto.GatheringDetailResponse;
 import com.runto.domain.gathering.dto.GatheringMember;
 import com.runto.domain.gathering.dto.GatheringsRequestParams;
 import com.runto.domain.gathering.dto.UserGatheringsRequestParams;
@@ -31,4 +32,7 @@ public interface GatheringRepositoryCustom {
                                         GatheringsRequestParams param);
 
     List<Gathering> getGeneralGatheringMap(Double radiusDistance, BigDecimal x, BigDecimal y);
+
+    GatheringDetailResponse getGatheringDetailWithUserParticipation(
+            Long gatheringId, Long userId);
 }

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringDetailContentResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringDetailContentResponse.java
@@ -3,30 +3,23 @@ package com.runto.domain.gathering.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.runto.domain.gathering.domain.Gathering;
-import com.runto.domain.gathering.type.GatheringStatus;
-import com.runto.domain.gathering.type.GatheringType;
-import com.runto.domain.gathering.type.GoalDistance;
-import com.runto.domain.gathering.type.RunningConcept;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.runto.domain.gathering.type.*;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 public class GatheringDetailContentResponse { // 이벤트 상세조회 시에도 사용될 예정
 
+    // 유의: dto로 바로 받아오는것으로 수정했기때문에, 만약 필드관련 수정 시 GatheringRepositoryCustomImpl - getGatheringDetailWithUserParticipation 도 수정 필요
     private Long id;
 
     private GatheringType type;
 
-    private Long organizerId;
+    //private Long organizerId;
 
     private String title;
 
@@ -44,7 +37,9 @@ public class GatheringDetailContentResponse { // 이벤트 상세조회 시에�
 
     private Long hits;
 
-    private LocationDto location;
+    private String addressFullName;
+
+    private CoordinatesDto coordinates;
 
     private GatheringStatus status;
 
@@ -52,22 +47,6 @@ public class GatheringDetailContentResponse { // 이벤트 상세조회 시에�
 
     private Integer currentNumber;
 
-    public static GatheringDetailContentResponse from(Gathering gathering) {
-        return GatheringDetailContentResponse.builder()
-                .id(gathering.getId())
-                .type(gathering.getGatheringType())
-                .organizerId(gathering.getOrganizerId())
-                .title(gathering.getTitle())
-                .description(gathering.getDescription())
-                .appointedAt(gathering.getAppointedAt())
-                .deadline(gathering.getDeadline())
-                .concept(gathering.getConcept())
-                .goalDistance(gathering.getGoalDistance())
-                .hits(gathering.getHits())
-                .location(LocationDto.from(gathering.getLocation()))
-                .status(gathering.getStatus())
-                .maxNumber(gathering.getMaxNumber())
-                .currentNumber(gathering.getCurrentNumber())
-                .build();
-    }
+    private EventRequestStatus eventRequestStatus; // 일반모임이면 해당 값은 null
+
 }

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringDetailResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringDetailResponse.java
@@ -2,28 +2,25 @@ package com.runto.domain.gathering.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.gathering.domain.Gathering;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(SnakeCaseStrategy.class)
 @Getter
-public class GatheringDetailResponse { // 멤버목록 가져오기는 api 분리로 수정
+public class GatheringDetailResponse {
 
-    private GatheringDetailContentResponse gatheringContentResponse;
+    // 유의: dto로 바로 받아오는 것으로 수정했기때문에, 만약 필드관련 수정 시 GatheringRepositoryCustomImpl - getGatheringDetailWithUserParticipation 도 수정 필요
 
-    
-    public static GatheringDetailResponse fromGathering(Gathering gathering) {
+    private boolean isParticipation;
 
-        return GatheringDetailResponse.builder()
-                .gatheringContentResponse(GatheringDetailContentResponse.from(gathering))
-                .build();
-    }
+    private Long organizerId;
+    private String organizerNickname;
+    private String organizerProfileUrl;
+
+    private GatheringDetailContentResponse content;
+
 
 }

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     GATHERING_NOT_FOUND(NOT_FOUND, "존재하지 않는 모임글입니다."),
     GATHERING_REPORTED(FORBIDDEN, "신고당한 모임글입니다."),
     EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW(FORBIDDEN, "승인상태가 아닌 이벤트모임은 주최자 본인만 볼 수 있습니다."),
+    EVENT_GATHERING_NOT_FOUND(NOT_FOUND, "이벤트 모임이지만, 이벤트에 대한 정보가 존재하지 않습니다. 관리자에게 문의해주세요."),
     GENERAL_MAX_NUMBER(BAD_REQUEST, "일반 모임의 최대 인원은 2명에서 10명 사이여야 합니다."),
     EVENT_GATHERING_MAX_NUMBER(BAD_REQUEST, "이벤트 모임의 최대 인원은 10명에서 300명 사이여야 합니다."),
     INVALID_ATTENDANCE_CHECK_NOT_ORGANIZER(FORBIDDEN, "모임의 주최자가 아니면 출석체크 할 수 없습니다."),


### PR DESCRIPTION
## 🔎 작업 내용

### 모임 상세조회 리팩토링

그냥 생각의 흐름 같은 것을 적은 
가독성 떨어지는 글이라
이번에도 읽고싶은 사람만 읽으세요

``참가/취소`` api를 구현하려고 해보니, 
먼저 ``참가/취소``  api를 분리할 것인가? 하나로 합칠 것인가?
일단 분리를 하는것이 restful 스럽고, 서로 다른 동작을 수행하는 것이라서, 분리를 하는 것이 요청의 의도를 명확하게 이해할 수 있다고 판단
참가의 경우 현재인원 변경, 멤버 데이터 자체를 새로 생성 -> POST
취소의 경우 현재인원 변경, 멤버 데이터 자체를 삭제 -> DELETE


그러면 프론트에서는 모임상세조회를 하고 있는 해당 유저가 
 ``참여 api`` 를 요청해야할지, ``참여취소 api`` 를 요청해야할지 알 수 있어야함.
(화면에 어떤 버튼을 띄워야하는지, 어떤 api로 날려야하는지)

그러면 해당 유저가 이 모임에 이미 참가상태인지 여부에 대한 데이터가 필요
(이 부분은 사실 api를 합치건, 합치지 않건 띄워야할 버튼 모습때문에 필요한 데이터인 듯함)

``그래서 결국 상세조회를 해올 때, 해당 유저의 참가 상태 데이터도 같이 보내야한다.``


물론 일반모임의 경우 최대인원이 10명 뿐이니까, Gathering과 GatheringMember를 패치 조인 해오고, 
그 안에서 해당 유저가 있는지 확인해도 무리가 없는 부분이지만, 

이벤트모임은 그렇게 할 수가 없다.
그리고 일반모임과 이벤트모임은 같은 테이블의 데이터다.
직접 Gathering을 가져와서 type을 확인하기 전까진, 해당 모임이 일반인지, 이벤트인지 알 수가 없다.


---
이건 이미 pr 날리고 난 뒤에 드는 생각을 끼워넣은 거라 처음 읽을 땐 제외하고 읽.. 
```직접 Gathering을 가져와서 type을 확인하기 전까진, 해당 모임이 일반인지, 이벤트인지 알 수가 없다.``` 에 대한 생각인데

### 이미 pr 날리고 나서 드는 생각인데 그냥 상세조회 api를 일반, 이벤트 용을 완전히 분리해서, 
### 조건문에 pk, 타입 값을 넣어서 조회를 하면,  일반 api로 조회했는데, 
### 해당 pk의 데이터가 이벤트면 조회 자체가 안되게끔 했어야하나 싶네요.
### 그러면 #85 의 고민과 설계로 진행 안했어도 싶은..
### 같은 테이블의 데이터라는 점과 재사용에 꽂혀서.. 넓게 생각을 못한 듯 싶네요
---


그러니까 
결국 Gathering 을 먼저 select 해오고, 
해당 Gathering 의 GatheringMember 가 있는지에 대한 쿼리를 또 날려야한다.

그런데 이미 사용자가 상세조회를 하게되면,
``텍스트데이터 가져오는 api 1회`` ,
 ``이미지데이터 api 1회``, 
 ``모임구성원 api 1회``(이건 사용자가 원할때만 요청하는 식이지만, 아마 결국 누를 것 같다.) - 분리한 이유  pr 참조 #85

이미 api를 여러번 요청하면서 쿼리를 오가는 횟수 많은 상태인데,
여기에 두 번 더 날리는 건 아니다싶었다.

그리고 주최자의 id, 닉네임, 프로필url 도 가져와야해서, ``총 3번``이나 더해지는 상황 .. (위에서 말한 이벤트모임의 경우 때문에, 한번에 가져올 수 없음)

그렇게 한 번의 쿼리문으로 해결할 방법을 고민했고, 여러 시도를 해봤습니다.
보통 가능하면 최대한 레파지토리에서는 엔티티로 받고, 서비스 단에서 dto로 변환해야한다는 점 때문에, 패치조인으로 해결해보려했으나,  패치조인으로는 불가능하다고 판단하였음. (사실 가능한데, 현재 지식이 부족해서 못 깨닫는 것인지는 모르겠으나..)
일단  ``패치 조인은 on 절 같은 것들을 별도로 사용 불가`` 한 것 같더군요.


처음부터 설계를 잘못했는지 여부를 떠나 지금 이 상황에서는 결국 dto로 받아와야만 1회의 쿼리로 해결 할 수 있다고 판단하였습니다.

- ### 응답 dto 수정 

```
public class GatheringDetailContentResponse { // 이벤트 상세조회 시에도 사용될 예정

    // 유의: dto로 바로 받아오는것으로 수정했기때문에, 만약 필드관련 수정 시 GatheringRepositoryCustomImpl - getGatheringDetailWithUserParticipation 도 수정 필요
    private Long id;

    private GatheringType type;

    //private Long organizerId;

    private String title;

    private String description;

    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
    private LocalDateTime appointedAt;

    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
    private LocalDateTime deadline;

    private RunningConcept concept;

    private GoalDistance goalDistance;

    private Long hits;

    private String addressFullName;

    private CoordinatesDto coordinates;

    private GatheringStatus status;

    private Integer maxNumber;

    private Integer currentNumber;

    private EventRequestStatus eventRequestStatus; // 일반모임이면 해당 값은 null

}
```
```
public class GatheringDetailResponse {

    // 유의: dto로 바로 받아오는 것으로 수정했기때문에, 만약 필드관련 수정 시 GatheringRepositoryCustomImpl - getGatheringDetailWithUserParticipation 도 수정 필요

    private boolean isParticipation;

    private Long organizerId;
    private String organizerNickname;
    private String organizerProfileUrl;

    private GatheringDetailContentResponse content;


}
```
   
-  ### 조회 쿼리 메서드 수정

```
    public GatheringDetailResponse getGatheringDetailWithUserParticipation(Long gatheringId, Long userId) {

        // 하나의 QGatheringMember 만 사용할 수 없는 상황이기때문에 따로 분리
        QGatheringMember organizer = new QGatheringMember("organizer");
        QGatheringMember participant = new QGatheringMember("participant");

        return jpaQueryFactory.select(Projections.fields(GatheringDetailResponse.class,

                        organizer.user.id.as("organizerId"),
                        organizer.user.nickname.as("organizerNickname"),
                        organizer.user.profileImageUrl.as("organizerProfileUrl"),

                        participant.isNotNull().as("isParticipation"), // 해당 모임에 대한 참가여부 (이 값 때문에 방식을 수정하기 시작)
                        Projections.fields(GatheringDetailContentResponse.class,
                                gathering.id.as("id"),
                                gathering.gatheringType.as("type"),
                                gathering.title.as("title"),
                                gathering.description.as("description"),
                                gathering.appointedAt.as("appointedAt"),
                                gathering.deadline.as("deadline"),
                                gathering.concept.as("concept"),
                                gathering.goalDistance.as("goalDistance"),
                                gathering.hits.as("hits"),
                                gathering.status.as("status"),
                                gathering.maxNumber.as("maxNumber"),
                                gathering.currentNumber.as("currentNumber"),
                                eventGathering.status.as("eventRequestStatus"),// 일반모임이면 null 으로 들어감
                                gathering.location.addressName.addressName.as("addressFullName"),
                                Projections.fields(CoordinatesDto.class,
                                                gathering.location.coordinates.x.as("x"),
                                                gathering.location.coordinates.y.as("y"))
                                        .as("coordinates")
                        ).as("content")
                ))
                .from(gathering, gathering)
                .join(gathering.gatheringMembers, organizer).on(organizer.role.eq(ORGANIZER))
                .leftJoin(gathering.eventGathering, eventGathering)  // 이벤트모임일 경우 필요한 값
                .leftJoin(gathering.gatheringMembers, participant).on(participant.user.id.eq(userId))  // 참가여부를 위한 값

                .where(gathering.id.eq(gatheringId))
                .fetchOne();

    }
```

![image](https://github.com/user-attachments/assets/683c2041-08f8-42ae-bf98-5e98fd248321)


원래는 위와 같은 erd 설계였다가, 바꾼 거 였는데, (참고 #27)
 지금의 형태는 주최자, 참가자가 같은 테이블에 있어서, 
 아래와 같이 같은 테이블에 대해 두 번이나 조인을 하는 요상한.. 형태가.. 됐는데, 
 처음의 형태로 하는게 나았을려나요... 후.. 

  .from(gathering, gathering)
  **.join(gathering.gatheringMembers, organizer).on(organizer.role.eq(ORGANIZER))**
  .leftJoin(gathering.eventGathering, eventGathering)  // 이벤트모임일 경우 필요한 값
 **.leftJoin(gathering.gatheringMembers, participant).on(participant.user.id.eq(userId))**  // 참가여부를 위한 값


---
QueryDSL 에서 중첩 dto를 받아보는건 처음이라 select 절 넣는 것도 헤맸고,
같은 테이블에서 참조하는 값이 다른 것도 처음이라, Q클래스를 두 개로 나눠서 만들어서 쓰는 것도 처음이었고, 
이런 쿼리문을 만들어보는 것도 처음이라 여러모로 멘붕이었네요. 특히 저 같은 테이블에서 두 놈 가져오는거..

진짜 이번 프로젝트하면서 sql  공부의 필요성을 아주 절실히 깨닫...
결국 jpql 하는데 막힘이 없으려면 sql을 잘해야..


- ### 서비스 메서드 수정

레파지토리에서 dto로 바로 받는 방식으로 바뀌면서, 
관련 서비스 메서드 안에서 검증 메서드들의 파라미터 값이 dto로 변경되었습니다.


## 🔧 리뷰 요구사항
> 원래 수정과 참가/취소 작업을 한번에 pr 하려고 했으나,  db 락을 적용에 대해 서칭하다보니, 시간이 계속 늦어질 것을 확실히 느낀 바... (보면 볼수록 계속 헷갈리네요.. 어떻게 구조를 잡아야할지도)
프론트와의 연동일정을 위해 우선 리팩토링 부분 먼저 pr 합니다.


<br/>
closed: #110 