### PR TITLE
♻️Refactor(#123): 모임글 등록, 이미지 등록 리팩토링

### DIFF
--- a/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
+++ b/src/main/java/com/runto/domain/gathering/dto/CreateGatheringRequest.java
@@ -38,7 +38,6 @@ public class CreateGatheringRequest {
     @NotNull(message = "약속장소는 필수값입니다.")
     private LocationDto location;
 
-    //@ValidGatheringMaxNumber // TODO 에러해결되면 교체 (현재는 서비스에서 따로 검증 후 예외발생시키는걸로 임시조치)
     private int maxNumber;
 
     @NotBlank(message = "본문 내용은 필수값입니다.")
@@ -50,13 +49,18 @@ public class CreateGatheringRequest {
 
     @NotNull(message = "목표 km 를 설정해야합니다.")
     private RunningConcept concept;
-    
+
 
     @Valid
-    private ImageRegisterResponse imageRegisterResponse;
+    private ImageRegisterResponse imageRegisterResponse; // 이미지 등록 자체를 안한다면 null
 
 
     public Gathering toEntity(User organizer, GatheringType type) {
+
+        String thumbnailUrl =
+                (imageRegisterResponse == null) ?
+                        null : imageRegisterResponse.getRepresentativeImageUrl();
+
 
         return Gathering.builder()
                 .organizerId(organizer.getId())
@@ -66,7 +70,7 @@ public class CreateGatheringRequest {
                 .deadline(deadline)
                 .concept(concept)
                 .goalDistance(goalDistance)
-                .thumbnailUrl(imageRegisterResponse.getRepresentativeImageUrl())
+                .thumbnailUrl(thumbnailUrl)
                 .location(location.toLocation())
                 .maxNumber(maxNumber)
                 .gatheringType(type)

--- a/src/main/java/com/runto/domain/image/api/ImageController.java
+++ b/src/main/java/com/runto/domain/image/api/ImageController.java
@@ -23,7 +23,7 @@ public class ImageController {
     @Operation(summary = "모임글 이미지 등록 (1~3개 가능)")
     @PostMapping("/gatherings")
     public ResponseEntity<ImageRegisterResponse> registerGatheringImages(
-            @RequestPart(value = "representative_image_index") Integer representativeImageIndex,
+            @RequestPart(value = "representative_image_index") int representativeImageIndex,
             @RequestPart(value = "images") List<MultipartFile> images,
             @RequestPart(value = "image_order") int[] imageOrder) { // 안에 하나하나 null 체크 하는 것보다 0으로 받기로 함
 

--- a/src/main/java/com/runto/domain/image/application/ImageService.java
+++ b/src/main/java/com/runto/domain/image/application/ImageService.java
@@ -2,6 +2,7 @@ package com.runto.domain.image.application;
 
 import com.runto.domain.image.dao.GatheringImageRepository;
 import com.runto.domain.image.dto.*;
+import com.runto.domain.image.exception.ImageException;
 import com.runto.domain.image.type.ImageUrlsResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+
+import static com.runto.global.exception.ErrorCode.INVALID_FILE;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,7 +25,9 @@ public class ImageService {
 
         log.info("모임글 이미지 등록 서비스 진입");
 
-        if (uploadRequest == null) return null;
+        if (uploadRequest == null){
+            throw new ImageException(INVALID_FILE);
+        }
 
         List<ImageUrlDto> contentImageUrls = s3ImageService
                 .uploadContentImages(uploadRequest.getImages(), "gathering");

--- a/src/main/java/com/runto/domain/image/application/S3ImageService.java
+++ b/src/main/java/com/runto/domain/image/application/S3ImageService.java
@@ -47,8 +47,9 @@ public class S3ImageService {
 
         log.info("모임글 이미지 등록 S3서비스 진입");
         if (images == null || images.size() < 1) {
-            return null;
+            throw new ImageException(INVALID_FILE);
         }
+
         List<ImageUrlDto> imageUrls = new ArrayList<>();
         images.forEach(imageDto -> imageUrls
                 .add(uploadImage(imageDto, imageNamePrefix)));
@@ -64,6 +65,10 @@ public class S3ImageService {
 
         try {
             MultipartFile requestFile = imageDto.getMultipartFile();
+
+            if (requestFile == null || !StringUtils.hasText(requestFile.getOriginalFilename())) {
+                throw new ImageException(INVALID_FILE);
+            }
 
             // 지원하는 이미지 확장자 파일인지 검증
             validateImageExtension(requestFile);
@@ -155,9 +160,9 @@ public class S3ImageService {
 
     private File convertToFile(String uniqueName, MultipartFile multipartFile) throws IOException {
 
-        if (multipartFile == null || multipartFile.isEmpty()) {
-            throw new ImageException(INVALID_FILE);
-        }
+//        if (multipartFile == null || multipartFile.isEmpty()) {
+//            throw new ImageException(INVALID_FILE);
+//        }
 
         File file = new File(FILE_PATH + uniqueName + "." +
                 extractExtension(Objects.requireNonNull(multipartFile.getOriginalFilename())));
@@ -176,9 +181,9 @@ public class S3ImageService {
 
     private void validateImageExtension(MultipartFile multipartFile) {
 
-        if (multipartFile == null || !StringUtils.hasText(multipartFile.getOriginalFilename())) {
-            throw new ImageException(INVALID_FILE);
-        }
+//        if (multipartFile == null || !StringUtils.hasText(multipartFile.getOriginalFilename())) {
+//            throw new ImageException(INVALID_FILE);
+//        }
 
         String extension = extractExtension(multipartFile.getOriginalFilename());
         if (!SUPPORT_IMAGE_EXTENSION.contains(extension)) {

--- a/src/main/java/com/runto/domain/image/dto/ImageRegisterResponse.java
+++ b/src/main/java/com/runto/domain/image/dto/ImageRegisterResponse.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.image.exception.ImageException;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,22 +19,21 @@ import static com.runto.global.exception.ErrorCode.INVALID_REPRESENTATIVE_IMAGE_
 @AllArgsConstructor
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class ImageRegisterResponse {
+public class ImageRegisterResponse { // 이미지 업로드 api 반환값으로 만들어지고, 모임글 등록 api 에서 그대로 요청값으로도 쓰임
 
-    private Integer representativeImageIndex;
+    @Min(value = 0, message = "인덱스는 음수값일 수 없습니다.")
+    private int representativeImageIndex;
 
     @Valid
-    @Size(max = 3, message = "이미지 등록은 최대 3개까지만 허용됩니다.")
+    @NotNull(message = "등록하려는 이미지 url이  존재하지 않습니다.")
+    @Size(min = 1, max = 3, message = "이미지 등록은 1~3개까지만 허용됩니다.")
     private List<ImageUrlDto> contentImageUrls;
 
-    public static ImageRegisterResponse of(Integer representativeImageIndex, List<ImageUrlDto> imageUrls) {
 
-        if (representativeImageIndex == null || representativeImageIndex < 0) {
-            representativeImageIndex = 0;
-        }
-        if (imageUrls == null || representativeImageIndex > imageUrls.size()) {
-            throw new ImageException(INVALID_REPRESENTATIVE_IMAGE_INDEX);
-        }
+    // 이미지 업로드 api 반환값으로써 쓰일 때
+    public static ImageRegisterResponse of(int representativeImageIndex, List<ImageUrlDto> imageUrls) {
+
+        validateImageIndex(representativeImageIndex, imageUrls);
 
         return ImageRegisterResponse.builder()
                 .representativeImageIndex(representativeImageIndex)
@@ -40,8 +41,18 @@ public class ImageRegisterResponse {
                 .build();
     }
 
+    private static void validateImageIndex(int representativeImageIndex, List<ImageUrlDto> imageUrls) {
+        if (representativeImageIndex < 0) representativeImageIndex = 0;
+
+        if (imageUrls == null || representativeImageIndex > imageUrls.size() - 1) {
+            throw new ImageException(INVALID_REPRESENTATIVE_IMAGE_INDEX);
+        }
+    }
 
     public String getRepresentativeImageUrl() {
+
+        validateImageIndex(this.representativeImageIndex, this.contentImageUrls);
+
         return contentImageUrls
                 .get(representativeImageIndex)
                 .getImageUrl();

--- a/src/main/java/com/runto/domain/image/dto/ImageUploadRequest.java
+++ b/src/main/java/com/runto/domain/image/dto/ImageUploadRequest.java
@@ -11,8 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static com.runto.global.exception.ErrorCode.IMAGE_ORDER_MISMATCH;
-import static com.runto.global.exception.ErrorCode.INVALID_REPRESENTATIVE_IMAGE_INDEX;
+import static com.runto.global.exception.ErrorCode.*;
 
 @Builder
 @NoArgsConstructor
@@ -23,17 +22,16 @@ public class ImageUploadRequest {
     List<ImageDto> images;
     private int representativeImageIndex;
 
-    public static ImageUploadRequest of(Integer representativeImageIndex,
+    public static ImageUploadRequest of(int representativeImageIndex,
                                         List<MultipartFile> imageFiles,
-                                        int[] contentImageOrder) {
+                                        int[] contentImageOrders) {
 
         if (imageFiles == null || imageFiles.size() < 1) {
-            return null;
+            throw new ImageException(INVALID_FILE);
         }
-        if (representativeImageIndex == null || representativeImageIndex < 0) {
-            representativeImageIndex = 0;
-        }
-        if (contentImageOrder == null || contentImageOrder.length != imageFiles.size()) {
+        if (representativeImageIndex < 0) representativeImageIndex = 0;
+
+        if (contentImageOrders == null || contentImageOrders.length != imageFiles.size()) {
             throw new ImageException(IMAGE_ORDER_MISMATCH);
         }
         if (representativeImageIndex > imageFiles.size() - 1) {
@@ -42,7 +40,7 @@ public class ImageUploadRequest {
 
         List<ImageDto> images = new ArrayList<>();
         IntStream.range(0, imageFiles.size())
-                .forEach(i -> images.add(new ImageDto(imageFiles.get(i), contentImageOrder[i])));
+                .forEach(i -> images.add(new ImageDto(imageFiles.get(i), contentImageOrders[i])));
 
         return ImageUploadRequest.builder()
                 .representativeImageIndex(representativeImageIndex)

--- a/src/main/java/com/runto/domain/image/dto/ImageUrlDto.java
+++ b/src/main/java/com/runto/domain/image/dto/ImageUrlDto.java
@@ -3,6 +3,7 @@ package com.runto.domain.image.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.runto.domain.image.domain.GatheringImage;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 public class ImageUrlDto {
 
     @Pattern(regexp = "^(https?|ftp)://[^\\s/$.?#].[^\\s]*\\.(webp)$", message = "유효하지 않은 이미지 URL입니다.")
+    @NotBlank(message = "등록하려는 이미지 url 이 존재하지 않습니다.")
     private String imageUrl;
 
     private int order;


### PR DESCRIPTION
## 🔎 작업 내용

### 모임등록, 이미지업로드 기능 리팩토링
 **모임글 등록 시 이미지 등록을 아예 하지 않는 경우, 이미지 업로드 api 자체를 요청하지 않는 방식으로 수정** 
  - 이미지 업로드를 하지 않을 경우, null 로 반환하던 것을 예외처리로 변경
  - 이미지 업로드 api 의 파람값을 모두 필수값으로 변경, 내부 로직 모두 null 에 대해 예외처리로 변경
  -  null 값을 허용하지않는 구조로 변경 (대표이미지 인덱스 등)
  - 누락된 예외처리 부분 추가



<br/>
closed: #123 