### PR TITLE
♻️Refactor(#129): 모임글 이미지 등록 api 요청값 형태 수정

### DIFF
--- a/src/main/java/com/runto/domain/image/api/ImageController.java
+++ b/src/main/java/com/runto/domain/image/api/ImageController.java
@@ -1,8 +1,10 @@
 package com.runto.domain.image.api;
 
 import com.runto.domain.image.application.ImageService;
+import com.runto.domain.image.dto.ImageDto;
 import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUploadRequest;
+import com.runto.domain.image.dto.RegisterImagesRequest;
 import com.runto.domain.image.type.ImageUrlsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -23,13 +26,14 @@ public class ImageController {
     @Operation(summary = "모임글 이미지 등록 (1~3개 가능)")
     @PostMapping("/gatherings")
     public ResponseEntity<ImageRegisterResponse> registerGatheringImages(
-            @RequestPart(value = "representative_image_index") int representativeImageIndex,
             @RequestPart(value = "images") List<MultipartFile> images,
-            @RequestPart(value = "image_order") int[] imageOrder) { // 안에 하나하나 null 체크 하는 것보다 0으로 받기로 함
+            @RequestPart(value = "request") RegisterImagesRequest request) { // 안에 하나하나 null 체크 하는 것보다 0으로 받기로 함
 
         log.info("모임글 이미지 등록 컨트롤러 진입={}", images);
         return ResponseEntity.ok(imageService.registerGatheringImages(
-                ImageUploadRequest.of(representativeImageIndex, images, imageOrder)));
+                ImageUploadRequest.of(
+                        request.getRepresentativeImageIndex(), images,
+                        request.getImageOrders())));
     }
 
     @Operation(summary = "모임글 이미지주소 목록 가져오기 (모임글 상세조회에 사용)")

--- a/src/main/java/com/runto/domain/image/dto/RegisterImagesRequest.java
+++ b/src/main/java/com/runto/domain/image/dto/RegisterImagesRequest.java
@@ -1,0 +1,18 @@
+package com.runto.domain.image.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class RegisterImagesRequest {
+
+    private int representativeImageIndex;
+
+    @NotNull(message = "imageOrders 은 필수값입니다.")
+    @Size(min = 1, max = 3, message = "imageOrders 값은 필수값입니다.")
+    private int[] imageOrders;
+}


### PR DESCRIPTION
## 🔎 작업 내용

### before
![image](https://github.com/user-attachments/assets/afc662bc-4d6d-475f-b38a-81446e759ec4)


---
### after
![image](https://github.com/user-attachments/assets/e274aa3d-e1d6-4181-8387-7dffbf31ba4b)

```
    @Operation(summary = "모임글 이미지 등록 (1~3개 가능)")
    @PostMapping("/gatherings")
    public ResponseEntity<ImageRegisterResponse> registerGatheringImages(
            @RequestPart(value = "images") List<MultipartFile> images,
            @RequestPart(value = "request") RegisterImagesRequest request) {
```


대표이미지인덱스, 순서 배열을 별도의 requestPart 로 받아오던 형식을
하나의 dto로 묶어서 받는 방식으로 수정
포스트맨에서는 문제가 전혀 없는데, 연동 시에는 자꾸 에러가 뜨네요.

별도로 받아도 리액트 코드에서 정상적으로 요청하는 방법이 있는지는 아직 모르겠으나, multipart 파일과, json 형식을 같이 보내는 방법을 탐색한 후 
모두 파일을 제외한 값은 하나의 dto로 묶어서 보내는 방법으로 수정하기로 하였음


### pr 머지 후  느낀점


```
수정 전 문제가 있던 리액트 코드

    const formData = new FormData();
    formData.append("representative_image_index", 0);
    formData.append("images", file); 
    formData.append("image_order", JSON.stringify([1])); 
    try {
        const response = await axios.post("http://localhost:8080/images/gatherings", formData, {
            headers: {
                "Content-Type": "multipart/form-data",
            },
        });
```

```
현재 pr에서는 결국 하나의 dto로 받는 형식으로 바꿨는데, 
하나의 json 객체로 묶지 않고, 
리액트에서 

 const data1 = {
      representative_image_index: 0
    };

    const data2 = {
      image_order: [0],
    };

만들어서 

    const json1 = JSON.stringify(data1);
    const blob = new Blob([json1], { type: 'application/json' });

    const json2= JSON.stringify(data2);
    const blob = new Blob([json2], { type: 'application/json' });

    formData.append('data', blob1);
    formData.append('data', blob2);
    
이렇게 별도의 json 으로 넣어서 보냈었다면 수정을 안해도  문제없이 됐을 것 같다.
    
```

closed:  #129
