### PR TITLE
✨Feat( #90): 그룹채팅 생성, 참가, 목록조회, 목록에서 채팅방조회, 채팅

### DIFF
--- a/src/main/java/com/runto/domain/admin/application/AdminService.java
+++ b/src/main/java/com/runto/domain/admin/application/AdminService.java
@@ -93,7 +93,7 @@ public class AdminService {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
-        Gathering gathering = gatheringRepository.findGatheringById(eventGathering.getGathering().getId())
+        Gathering gathering = gatheringRepository.findById(eventGathering.getGathering().getId())
                 .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
 
         // 주최자인지 확인

--- a/src/main/java/com/runto/domain/chat/api/DirectChatController.java
+++ b/src/main/java/com/runto/domain/chat/api/DirectChatController.java
@@ -8,7 +8,9 @@ import com.runto.domain.chat.dto.MessageResponse;
 import com.runto.global.security.detail.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -23,11 +25,10 @@ public class DirectChatController {
     //1:1 채팅방 1:1채팅하기로 조회(생성과 같이 있음)
     @GetMapping
     public ResponseEntity<ChatResponse> getDirectChatRoom(@RequestParam(name = "other_id") Long otherId,
-                                                          @RequestParam(name = "page_num") int pageNum,
-                                                          @RequestParam(defaultValue = "7") int size,
+                                                          @PageableDefault(size = 7) Pageable pageable,
                                                           @AuthenticationPrincipal CustomUserDetails userDetails){
         DirectChatInfoDTO directChatInfoDTO = directChatService.createAndGetDirectChat(userDetails.getUserId(),otherId);
-        Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(directChatInfoDTO.getRoomId(),pageNum,size);
+        Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(directChatInfoDTO.getRoomId(),pageable);
         ChatResponse chatResponse = ChatResponse.builder()
                 .roomId(directChatInfoDTO.getRoomId())
                 .messages(messageResponses).build();
@@ -37,17 +38,15 @@ public class DirectChatController {
     //1:1 채팅방 목록 조회
     @GetMapping("/list")
     public ResponseEntity<Slice<ChatRoomResponse>> getDirectChatRoomList(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                         @RequestParam(name = "page_num") int pageNum,
-                                                                         @RequestParam(defaultValue = "7") int size){
-        return ResponseEntity.ok(directChatService.getDirectChatRoomList(userDetails.getUserId(), pageNum,size));
+                                                                         @PageableDefault(size = 7) Pageable pageable){
+        return ResponseEntity.ok(directChatService.getDirectChatRoomList(userDetails.getUserId(), pageable));
     }
 
     //1:1 채팅방 조회 (목록에서)
     @GetMapping("/{room_id}")
     public ResponseEntity<ChatResponse> getDirectChatRoomFromList(@PathVariable(name = "room_id") Long roomId,
-                                                                  @RequestParam(name = "page_num") int pageNum,
-                                                                  @RequestParam(defaultValue = "7") int size){
-        Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(roomId,pageNum,size);
+                                                                  @PageableDefault(size = 7) Pageable pageable){
+        Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(roomId,pageable);
         ChatResponse chatResponse = ChatResponse.builder()
                 .roomId(roomId)
                 .messages(messageResponses).build();

--- a/src/main/java/com/runto/domain/chat/api/DirectChatController.java
+++ b/src/main/java/com/runto/domain/chat/api/DirectChatController.java
@@ -1,9 +1,9 @@
 package com.runto.domain.chat.api;
 
 import com.runto.domain.chat.application.DirectChatService;
+import com.runto.domain.chat.dto.ChatResponse;
+import com.runto.domain.chat.dto.ChatRoomResponse;
 import com.runto.domain.chat.dto.DirectChatInfoDTO;
-import com.runto.domain.chat.dto.DirectChatResponse;
-import com.runto.domain.chat.dto.DirectChatRoomResponse;
 import com.runto.domain.chat.dto.MessageResponse;
 import com.runto.global.security.detail.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -22,36 +22,36 @@ public class DirectChatController {
 
     //1:1 채팅방 1:1채팅하기로 조회(생성과 같이 있음)
     @GetMapping
-    public ResponseEntity<DirectChatResponse> getDirectChatRoom(@RequestParam(name = "other_id") Long otherId,
-                                                                @RequestParam(name = "page_num") int pageNum,
-                                                                @RequestParam(defaultValue = "7") int size,
-                                                                @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<ChatResponse> getDirectChatRoom(@RequestParam(name = "other_id") Long otherId,
+                                                          @RequestParam(name = "page_num") int pageNum,
+                                                          @RequestParam(defaultValue = "7") int size,
+                                                          @AuthenticationPrincipal CustomUserDetails userDetails){
         DirectChatInfoDTO directChatInfoDTO = directChatService.createAndGetDirectChat(userDetails.getUserId(),otherId);
         Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(directChatInfoDTO.getRoomId(),pageNum,size);
-        DirectChatResponse directChatResponse = DirectChatResponse.builder()
+        ChatResponse chatResponse = ChatResponse.builder()
                 .roomId(directChatInfoDTO.getRoomId())
                 .messages(messageResponses).build();
-        return ResponseEntity.ok(directChatResponse);
+        return ResponseEntity.ok(chatResponse);
     }
 
     //1:1 채팅방 목록 조회
     @GetMapping("/list")
-    public ResponseEntity<Slice<DirectChatRoomResponse>> getDirectChatRoomList(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                               @RequestParam(name = "page_num") int pageNum,
-                                                                               @RequestParam(defaultValue = "7") int size){
+    public ResponseEntity<Slice<ChatRoomResponse>> getDirectChatRoomList(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                         @RequestParam(name = "page_num") int pageNum,
+                                                                         @RequestParam(defaultValue = "7") int size){
         return ResponseEntity.ok(directChatService.getDirectChatRoomList(userDetails.getUserId(), pageNum,size));
     }
 
     //1:1 채팅방 조회 (목록에서)
     @GetMapping("/{room_id}")
-    public ResponseEntity<DirectChatResponse> getDirectChatRoomFromList(@PathVariable(name = "room_id") Long roomId,
-                                                          @RequestParam(name = "page_num") int pageNum,
-                                                          @RequestParam(defaultValue = "7") int size){
+    public ResponseEntity<ChatResponse> getDirectChatRoomFromList(@PathVariable(name = "room_id") Long roomId,
+                                                                  @RequestParam(name = "page_num") int pageNum,
+                                                                  @RequestParam(defaultValue = "7") int size){
         Slice<MessageResponse> messageResponses = directChatService.getDirectChatMessages(roomId,pageNum,size);
-        DirectChatResponse directChatResponse = DirectChatResponse.builder()
+        ChatResponse chatResponse = ChatResponse.builder()
                 .roomId(roomId)
                 .messages(messageResponses).build();
-        return ResponseEntity.ok(directChatResponse);
+        return ResponseEntity.ok(chatResponse);
     }
 
 }

--- a/src/main/java/com/runto/domain/chat/api/GroupChatController.java
+++ b/src/main/java/com/runto/domain/chat/api/GroupChatController.java
@@ -1,31 +1,55 @@
 package com.runto.domain.chat.api;
 
 
+import com.runto.domain.chat.application.GroupChatService;
+import com.runto.domain.chat.dto.ChatResponse;
+import com.runto.domain.chat.dto.ChatRoomResponse;
+import com.runto.domain.chat.dto.MessageResponse;
+import com.runto.global.security.detail.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/chat/group")
 @RequiredArgsConstructor
 public class GroupChatController {
 
-    /**
-     * 그룹 채팅 생성, 참가 api 를 따로 만들까?
-     * !!따로 만들 경우
-     * 명확한 책임의 분리가 가능함.
-     * 클라이언트에게 두번 요청을 받아야함.
-     * 채팅방의 동시성 제어를 따로 해줘야함.
-     * 한번의 처리에 대한 데이터 처리량이 줄어든다.
-     *
-     * !!모임 서비스에서 한번에 처리할 경우
-     * 엔티티에 대한 접근(쿼리)이 줄어든다.
-     * 동시성처리는 모임 생성,참가에서 하면 채팅방도 동시성 해결
-     * 한번에 처리에 대한 데이터 처리량이 증가함.
-     * 채팅 생성 api 따로 없으므로 채팅 생성, 참가를 따로 하고싶을 경우의 기능의 확장성 없음
-     */
+    private final GroupChatService groupChatService;
 
-    //그룹 채팅 생성 api
+    //그룹 채팅 생성 api -> 생성자는 자동으로 참가되야함
+    @PostMapping
+    public void createGroupChat(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                @RequestParam("id") Long gatheringId){
+        groupChatService.createGroupChatRoom(gatheringId);
+        groupChatService.joinGroupChatRoom(userDetails.getUserId(), gatheringId);
+    }
 
     //그룹 채팅 참가 api
+    @PostMapping("/join")
+    public void joinGroupChat(@AuthenticationPrincipal CustomUserDetails userDetails,
+                              @RequestParam("id") Long gatheringId){
+        groupChatService.joinGroupChatRoom(userDetails.getUserId(), gatheringId);
+    }
+    //그룹 채팅방 목록 조회
+    @GetMapping("/list")
+    public ResponseEntity<Slice<ChatRoomResponse>> getGroupChatList(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                    @RequestParam(name = "page_num") int pageNum,
+                                                                    @RequestParam(defaultValue = "7") int size){
+        return ResponseEntity.ok(groupChatService.getGroupChatRoomList(userDetails.getUserId(),pageNum ,size));
+    }
+    //그룹 채팅방 목록에서 조회
+    @GetMapping("/{room_id}")
+    public ResponseEntity<ChatResponse> getGroupChatRoom(@PathVariable("room_id") Long roomId,
+                                                         @RequestParam(name = "page_num") int pageNum,
+                                                         @RequestParam(defaultValue = "7") int size){
+        Slice<MessageResponse> messageResponses = groupChatService.getGroupChatRoom(roomId,pageNum,size);
+        ChatResponse chatResponse = ChatResponse.builder()
+                .roomId(roomId)
+                .messages(messageResponses).build();
+
+        return ResponseEntity.ok(chatResponse);
+    }
 }

--- a/src/main/java/com/runto/domain/chat/api/GroupChatController.java
+++ b/src/main/java/com/runto/domain/chat/api/GroupChatController.java
@@ -7,7 +7,9 @@ import com.runto.domain.chat.dto.ChatRoomResponse;
 import com.runto.domain.chat.dto.MessageResponse;
 import com.runto.global.security.detail.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -36,16 +38,14 @@ public class GroupChatController {
     //그룹 채팅방 목록 조회
     @GetMapping("/list")
     public ResponseEntity<Slice<ChatRoomResponse>> getGroupChatList(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                    @RequestParam(name = "page_num") int pageNum,
-                                                                    @RequestParam(defaultValue = "7") int size){
-        return ResponseEntity.ok(groupChatService.getGroupChatRoomList(userDetails.getUserId(),pageNum ,size));
+                                                                    @PageableDefault(size = 7) Pageable pageable){
+        return ResponseEntity.ok(groupChatService.getGroupChatRoomList(userDetails.getUserId(),pageable));
     }
     //그룹 채팅방 목록에서 조회
     @GetMapping("/{room_id}")
     public ResponseEntity<ChatResponse> getGroupChatRoom(@PathVariable("room_id") Long roomId,
-                                                         @RequestParam(name = "page_num") int pageNum,
-                                                         @RequestParam(defaultValue = "7") int size){
-        Slice<MessageResponse> messageResponses = groupChatService.getGroupChatRoom(roomId,pageNum,size);
+                                                         @PageableDefault(size = 7) Pageable pageable){
+        Slice<MessageResponse> messageResponses = groupChatService.getGroupChatRoom(roomId,pageable);
         ChatResponse chatResponse = ChatResponse.builder()
                 .roomId(roomId)
                 .messages(messageResponses).build();

--- a/src/main/java/com/runto/domain/chat/api/ProducerController.java
+++ b/src/main/java/com/runto/domain/chat/api/ProducerController.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 public class ProducerController {
     private final ProducerService producerService;
 
-    //웹소켓 메시지 전송
+    //1:1 채팅 웹소켓 메시지 전송
     @MessageMapping("/send/direct")
     public void sendDirectMessage(@Payload MessageDTO messageDTO,
                                   @AuthenticationPrincipal CustomUserDetails userDetails){
@@ -28,9 +28,9 @@ public class ProducerController {
         producerService.sendDirectMessage(messageDTO, userDetails.getUserId());
     }
 
-    //테스트 메시지 전송 api
-    @PostMapping("/send/message")
-    public void sendMessage(@RequestBody MessageDTO messageDTO,
+    //1:1 채팅 테스트 메시지 전송 api
+    @PostMapping("/send/message/direct")
+    public void sendMessageDirect(@RequestBody MessageDTO messageDTO,
                             @AuthenticationPrincipal CustomUserDetails userDetails){
         if (messageDTO.getTimestamp() == null){
             messageDTO.setTimestamp(LocalDateTime.now());

--- a/src/main/java/com/runto/domain/chat/api/ProducerController.java
+++ b/src/main/java/com/runto/domain/chat/api/ProducerController.java
@@ -37,4 +37,24 @@ public class ProducerController {
         }
         producerService.sendDirectMessage(messageDTO, userDetails.getUserId());
     }
+
+    //그룹 채팅 웹소켓 메시지 전송
+    @MessageMapping("/send/group")
+    public void sendGroupMessage(@Payload MessageDTO messageDTO,
+                                  @AuthenticationPrincipal CustomUserDetails userDetails){
+        if (messageDTO.getTimestamp() == null){
+            messageDTO.setTimestamp(LocalDateTime.now());
+        }
+        producerService.sendGroupMessage(messageDTO, userDetails.getUserId());
+    }
+
+    //그룹 채팅 테스트 메시지 전송 api
+    @PostMapping("/send/message/group")
+    public void sendMessageGroup(@RequestBody MessageDTO messageDTO,
+                            @AuthenticationPrincipal CustomUserDetails userDetails){
+        if (messageDTO.getTimestamp() == null){
+            messageDTO.setTimestamp(LocalDateTime.now());
+        }
+        producerService.sendGroupMessage(messageDTO, userDetails.getUserId());
+    }
 }

--- a/src/main/java/com/runto/domain/chat/application/ConsumerService.java
+++ b/src/main/java/com/runto/domain/chat/application/ConsumerService.java
@@ -32,6 +32,7 @@ public class ConsumerService {
     private final SimpMessagingTemplate simpleMessagingTemplate;
     private final UserRepository userRepository;
     private final DirectChatService directChatService;
+    private final GroupChatService groupChatService;
     private final RetryTemplate retryTemplate;
     private final RabbitTemplate rabbitTemplate;
 
@@ -43,51 +44,16 @@ public class ConsumerService {
 
     @RabbitListener(queues = "${rabbit.direct.queue}",concurrency = "5-10",ackMode = "MANUAL")
     public void receiveDirectMessage(String message, Channel channel, Message amqpMessage){
-
-        try {
-            log.info("received direct message = {}",message);
-            channel.basicAck(amqpMessage.getMessageProperties().getDeliveryTag(),false);
-            ObjectMapper objectMapper = new ObjectMapper();
-            MessageQueueDTO messageQueueDTO = objectMapper.readValue(message, MessageQueueDTO.class);
-
-            User user = userRepository.findById(messageQueueDTO.getSenderId())
-                    .orElseThrow(()->new ChatException(ErrorCode.USER_NOT_FOUND));
-
-            MessageResponse messageResponse = MessageResponse.of(messageQueueDTO,user);
-
-            boolean messageSent = retryTemplate.execute(new RetryCallback<Boolean, Exception>() {
-                @Override
-                public Boolean doWithRetry(RetryContext context) throws Exception {
-                    try {
-                        simpleMessagingTemplate.convertAndSend("/topic/direct/" + messageQueueDTO.getRoomId(), messageResponse);
-                        return true;
-                    }catch (MessagingException e){
-                        log.error("Send message Failed = {}",messageResponse,e);
-                        throw e;
-                    }
-                }
-            }, new RecoveryCallback<Boolean>() {
-                @Override
-                public Boolean recover(RetryContext context) throws Exception {
-                    //모든 재시도 실패했을때의 처리
-                    log.error("Send Message to client and retry this. message = {}", messageResponse);
-                    return false;
-                }
-            });
-
-            directChatService.saveDirectChatContent(messageQueueDTO, messageSent);
-
-        }catch (JsonProcessingException e){
-            log.error("Message parsing error to directMessage = {}",e.getMessage());
-            deleteMessageNAckAndSendDLQueue(message,channel,amqpMessage);
-        }catch (Exception e){
-            log.error("UnExpected error = {}",e.getMessage());
-            deleteMessageNAckAndSendDLQueue(message,channel,amqpMessage);
-        }
+        processMessage(message,channel,amqpMessage,"direct");
     }
+
+    @RabbitListener(queues = "${rabbit.group.queue}",concurrency = "5-10",ackMode = "MANUAL")
+    public void receiveGroupMessage(String message, Channel channel, Message amqpMessage){
+        processMessage(message,channel,amqpMessage,"group");
+    }
+
     @RabbitListener(queues = "${rabbit.dl.queue}")
     public void receiveDeadLetterMessage(String message){
-        //데드레터 로그찍기 -> 저장은 나중에 생각해보기
         log.error("Receive deadLetterMessage in queue = {}",message);
     }
 
@@ -99,6 +65,57 @@ public class ConsumerService {
             channel.basicNack(amqpMessage.getMessageProperties().getDeliveryTag(), false, false);
         } catch (IOException ioException) {
             log.error("IOException during basicNack: {}", ioException.getMessage());
+        }
+    }
+
+
+    private boolean sendMessageWithRetry(MessageQueueDTO messageQueueDTO, MessageResponse messageResponse, String messageType) throws Exception {
+        return retryTemplate.execute(new RetryCallback<Boolean, Exception>() {
+            @Override
+            public Boolean doWithRetry(RetryContext context) throws Exception {
+                try {
+                    simpleMessagingTemplate.convertAndSend("/topic/" + messageType + "/" + messageQueueDTO.getRoomId(), messageResponse);
+                    return true;
+                } catch (MessagingException e) {
+                    log.error("{} message failed to send: {}", messageType, messageResponse, e);
+                    throw e;
+                }
+            }
+        }, new RecoveryCallback<Boolean>() {
+            @Override
+            public Boolean recover(RetryContext context) {
+                log.error("Retry failed to send {} message: {}", messageType, messageResponse);
+                return false;
+            }
+        });
+    }
+
+    private void processMessage(String message, Channel channel, Message amqpMessage,String messageType){
+        try {
+            log.info("received group message = {}",message);
+            channel.basicAck(amqpMessage.getMessageProperties().getDeliveryTag(),false);
+            ObjectMapper objectMapper = new ObjectMapper();
+            MessageQueueDTO messageQueueDTO = objectMapper.readValue(message, MessageQueueDTO.class);
+
+            User user = userRepository.findById(messageQueueDTO.getSenderId())
+                    .orElseThrow(()->new ChatException(ErrorCode.USER_NOT_FOUND));
+
+            MessageResponse messageResponse = MessageResponse.of(messageQueueDTO,user);
+
+            boolean messageSent = sendMessageWithRetry(messageQueueDTO,messageResponse,messageType);
+
+            if (messageType.equals("direct")) {
+                directChatService.saveDirectChatContent(messageQueueDTO, messageSent);
+            } else if (messageType.equals("group")) {
+                groupChatService.saveGroupChatChatContent(messageQueueDTO, messageSent);
+            }
+
+        }catch (JsonProcessingException e){
+            log.error("Message parsing error to groupMessage = {}",e.getMessage());
+            deleteMessageNAckAndSendDLQueue(message,channel,amqpMessage);
+        }catch (Exception e){
+            log.error("UnExpected error to send Group = {}",e.getMessage());
+            deleteMessageNAckAndSendDLQueue(message,channel,amqpMessage);
         }
     }
 

--- a/src/main/java/com/runto/domain/chat/application/DirectChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/DirectChatService.java
@@ -4,8 +4,8 @@ import com.runto.domain.chat.dao.DirectChatRoomRepository;
 import com.runto.domain.chat.dao.DirectMessageRepository;
 import com.runto.domain.chat.domain.DirectChatContent;
 import com.runto.domain.chat.domain.DirectChatRoom;
+import com.runto.domain.chat.dto.ChatRoomResponse;
 import com.runto.domain.chat.dto.DirectChatInfoDTO;
-import com.runto.domain.chat.dto.DirectChatRoomResponse;
 import com.runto.domain.chat.dto.MessageQueueDTO;
 import com.runto.domain.chat.dto.MessageResponse;
 import com.runto.domain.chat.exception.ChatException;
@@ -81,22 +81,13 @@ public class DirectChatService {
         return DirectChatInfoDTO.of(directChatRoom.getId(),me.getId(),otherUser.getId());
     }
 
-    public Slice<DirectChatRoomResponse> getDirectChatRoomList(Long userId,int pageNum,int size){
+    public Slice<ChatRoomResponse> getDirectChatRoomList(Long userId, int pageNum, int size){
         User me = userRepository.findById(userId)
                 .orElseThrow(()->new UserException(ErrorCode.USER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(pageNum,size);
 
         return directChatRoomRepository.getChatRooms(me.getId(), pageable);
-    }
-
-    @Transactional
-    public void saveDirectChatContent(MessageQueueDTO messageQueueDTO, boolean messageSent){
-        DirectChatContent directChatContent = DirectChatContent.of(messageQueueDTO);
-        if (!messageSent){
-            directChatContent.changeStatusToFailed();
-        }
-        directMessageRepository.save(directChatContent);
     }
 
     public Slice<MessageResponse> getDirectChatMessages(Long roomId, int pageNum, int size){
@@ -119,4 +110,12 @@ public class DirectChatService {
         return new SliceImpl<>(messageResponses, pageable, directChatContents.hasNext());
     }
 
+    @Transactional
+    public void saveDirectChatContent(MessageQueueDTO messageQueueDTO, boolean messageSent){
+        DirectChatContent directChatContent = DirectChatContent.of(messageQueueDTO);
+        if (!messageSent){
+            directChatContent.changeStatusToFailed();
+        }
+        directMessageRepository.save(directChatContent);
+    }
 }

--- a/src/main/java/com/runto/domain/chat/application/DirectChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/DirectChatService.java
@@ -17,7 +17,6 @@ import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -81,17 +80,13 @@ public class DirectChatService {
         return DirectChatInfoDTO.of(directChatRoom.getId(),me.getId(),otherUser.getId());
     }
 
-    public Slice<ChatRoomResponse> getDirectChatRoomList(Long userId, int pageNum, int size){
+    public Slice<ChatRoomResponse> getDirectChatRoomList(Long userId, Pageable pageable){
         User me = userRepository.findById(userId)
                 .orElseThrow(()->new UserException(ErrorCode.USER_NOT_FOUND));
-
-        Pageable pageable = PageRequest.of(pageNum,size);
-
         return directChatRoomRepository.getChatRooms(me.getId(), pageable);
     }
 
-    public Slice<MessageResponse> getDirectChatMessages(Long roomId, int pageNum, int size){
-        Pageable pageable = PageRequest.of(pageNum,size);
+    public Slice<MessageResponse> getDirectChatMessages(Long roomId, Pageable pageable){
         LocalDateTime daysAgo = LocalDateTime.now().minusDays(2);
         Slice<DirectChatContent> directChatContents = directMessageRepository.findDirectChatContent(roomId, daysAgo, pageable);
 

--- a/src/main/java/com/runto/domain/chat/application/GroupChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/GroupChatService.java
@@ -10,6 +10,7 @@ import com.runto.domain.chat.dto.ChatRoomResponse;
 import com.runto.domain.chat.dto.MessageQueueDTO;
 import com.runto.domain.chat.dto.MessageResponse;
 import com.runto.domain.chat.exception.ChatException;
+import com.runto.domain.gathering.dao.GatheringMemberRepository;
 import com.runto.domain.gathering.dao.GatheringRepository;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.user.dao.UserRepository;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 public class GroupChatService {
     private final GroupChatRoomUserRepository groupChatRoomUserRepository;
     private final GatheringRepository gatheringRepository;
+    private final GatheringMemberRepository gatheringMemberRepository;
     private final GroupChatRoomRepository groupChatRoomRepository;
     private final UserRepository userRepository;
     private final GroupMessageRepository groupMessageRepository;
@@ -54,6 +56,11 @@ public class GroupChatService {
                 .orElseThrow(()->new ChatException(ErrorCode.USER_NOT_FOUND));
 
         GroupChatRoom groupChatRoom = groupChatRoomRepository.findByGatheringId(gatheringId);
+
+        //모임에 참여 중인지 확인
+        if (gatheringMemberRepository.existsGatheringMemberByGathering(gatheringId,userId)){
+            throw new ChatException(ErrorCode.GATHERING_MEMBER_NOT_FOUND);
+        }
 
         //내가 그 채팅방에 참여중인지 확인
         if (groupChatRoomUserRepository.existsByGroupChatRoomAndUser(groupChatRoom,user)){

--- a/src/main/java/com/runto/domain/chat/application/GroupChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/GroupChatService.java
@@ -58,7 +58,7 @@ public class GroupChatService {
         GroupChatRoom groupChatRoom = groupChatRoomRepository.findByGatheringId(gatheringId);
 
         //모임에 참여 중인지 확인
-        if (gatheringMemberRepository.existsGatheringMemberByGathering(gatheringId,userId)){
+        if (gatheringMemberRepository.existsGatheringMemberByGatheringIdAndUserId(gatheringId,userId)){
             throw new ChatException(ErrorCode.GATHERING_MEMBER_NOT_FOUND);
         }
 

--- a/src/main/java/com/runto/domain/chat/application/GroupChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/GroupChatService.java
@@ -2,24 +2,59 @@ package com.runto.domain.chat.application;
 
 import com.runto.domain.chat.dao.GroupChatRoomRepository;
 import com.runto.domain.chat.dao.GroupChatRoomUserRepository;
+import com.runto.domain.chat.dao.GroupMessageRepository;
+import com.runto.domain.chat.domain.GroupChatContent;
 import com.runto.domain.chat.domain.GroupChatRoom;
 import com.runto.domain.chat.domain.GroupChatRoomUser;
+import com.runto.domain.chat.dto.ChatRoomResponse;
+import com.runto.domain.chat.dto.MessageQueueDTO;
+import com.runto.domain.chat.dto.MessageResponse;
 import com.runto.domain.chat.exception.ChatException;
+import com.runto.domain.gathering.dao.GatheringRepository;
 import com.runto.domain.gathering.domain.Gathering;
+import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.User;
 import com.runto.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class GroupChatService {
     private final GroupChatRoomUserRepository groupChatRoomUserRepository;
+    private final GatheringRepository gatheringRepository;
+    private final GroupChatRoomRepository groupChatRoomRepository;
+    private final UserRepository userRepository;
+    private final GroupMessageRepository groupMessageRepository;
+
+    // 그룹 채팅방 생성
+    @Transactional
+    public void createGroupChatRoom(Long gatheringId){
+        Gathering gathering = gatheringRepository.findGatheringById(gatheringId)
+                .orElseThrow(()->new ChatException(ErrorCode.GATHERING_NOT_FOUND));
+
+        GroupChatRoom groupChatRoom = GroupChatRoom.createRoom(gathering);
+
+        groupChatRoomRepository.save(groupChatRoom);
+    }
 
     // 그룹 채팅방 참여
     @Transactional
-    public void joinGroupChatRoom(User user, GroupChatRoom groupChatRoom){
+    public void joinGroupChatRoom(Long userId, Long gatheringId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(()->new ChatException(ErrorCode.USER_NOT_FOUND));
+
+        GroupChatRoom groupChatRoom = groupChatRoomRepository.findByGatheringId(gatheringId);
 
         //내가 그 채팅방에 참여중인지 확인
         if (groupChatRoomUserRepository.existsByGroupChatRoomAndUser(groupChatRoom,user)){
@@ -27,5 +62,49 @@ public class GroupChatService {
         }
 
         groupChatRoom.addGroupChatUser(GroupChatRoomUser.createGroupChatRoomUser(groupChatRoom,user));
+    }
+
+    // 그룹 채팅방 목록 조회
+    @Transactional
+    public Slice<ChatRoomResponse> getGroupChatRoomList(Long userId, int pageNum, int size){
+        Pageable pageable = PageRequest.of(pageNum,size);
+        Slice<GroupChatRoom> groupChatRooms = groupChatRoomRepository.findGroupChatRoomById(userId, pageable);
+        System.out.println("groupChatRooms: " + groupChatRooms.getContent());
+        List<ChatRoomResponse> chatRoomResponses = groupChatRooms.stream().map(ChatRoomResponse::fromGroupChatRoom).toList();
+        System.out.println("chatRoomResponses: " + chatRoomResponses);
+        return new SliceImpl<>(chatRoomResponses, pageable, groupChatRooms.hasNext());
+    }
+
+
+    // 그룹 채팅방 목록에서 조회하기
+    public Slice<MessageResponse> getGroupChatRoom(Long roomId, int pageNum, int size){
+        LocalDateTime daysAgo = LocalDateTime.now().minusDays(2);
+        Pageable pageable = PageRequest.of(pageNum,size);
+
+        Slice<GroupChatContent> groupChatContents = groupMessageRepository.findGroupChatContent(roomId,daysAgo,pageable);
+
+        List<Long> senderIdList = groupChatContents.stream()
+                .map(GroupChatContent::getSenderId).distinct().toList();
+
+        List<User> users = userRepository.findAllById(senderIdList);
+
+        Map<Long, User> userMap = users.stream().collect(Collectors.toMap(User::getId, u->u));
+
+        List<MessageResponse> messageResponses = groupChatContents.stream().map(groupChatContent->{
+            User user = userMap.get(groupChatContent.getSenderId());
+            return MessageResponse.of(groupChatContent,user);
+
+        }).toList();
+
+        return new SliceImpl<>(messageResponses, pageable, groupChatContents.hasNext());
+    }
+
+    @Transactional
+    public void saveGroupChatChatContent(MessageQueueDTO messageQueueDTO, boolean messageSent){
+        GroupChatContent groupChatContent = GroupChatContent.of(messageQueueDTO);
+        if (!messageSent){
+            groupChatContent.changeStatusToFailed();
+        }
+        groupMessageRepository.save(groupChatContent);
     }
 }

--- a/src/main/java/com/runto/domain/chat/application/GroupChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/GroupChatService.java
@@ -16,7 +16,6 @@ import com.runto.domain.user.dao.UserRepository;
 import com.runto.domain.user.domain.User;
 import com.runto.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -66,8 +65,7 @@ public class GroupChatService {
 
     // 그룹 채팅방 목록 조회
     @Transactional
-    public Slice<ChatRoomResponse> getGroupChatRoomList(Long userId, int pageNum, int size){
-        Pageable pageable = PageRequest.of(pageNum,size);
+    public Slice<ChatRoomResponse> getGroupChatRoomList(Long userId, Pageable pageable){
         Slice<GroupChatRoom> groupChatRooms = groupChatRoomRepository.findGroupChatRoomById(userId, pageable);
         System.out.println("groupChatRooms: " + groupChatRooms.getContent());
         List<ChatRoomResponse> chatRoomResponses = groupChatRooms.stream().map(ChatRoomResponse::fromGroupChatRoom).toList();
@@ -77,9 +75,8 @@ public class GroupChatService {
 
 
     // 그룹 채팅방 목록에서 조회하기
-    public Slice<MessageResponse> getGroupChatRoom(Long roomId, int pageNum, int size){
+    public Slice<MessageResponse> getGroupChatRoom(Long roomId, Pageable pageable){
         LocalDateTime daysAgo = LocalDateTime.now().minusDays(2);
-        Pageable pageable = PageRequest.of(pageNum,size);
 
         Slice<GroupChatContent> groupChatContents = groupMessageRepository.findGroupChatContent(roomId,daysAgo,pageable);
 

--- a/src/main/java/com/runto/domain/chat/application/GroupChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/GroupChatService.java
@@ -41,7 +41,7 @@ public class GroupChatService {
     // 그룹 채팅방 생성
     @Transactional
     public void createGroupChatRoom(Long gatheringId){
-        Gathering gathering = gatheringRepository.findGatheringById(gatheringId)
+        Gathering gathering = gatheringRepository.findById(gatheringId)
                 .orElseThrow(()->new ChatException(ErrorCode.GATHERING_NOT_FOUND));
 
         GroupChatRoom groupChatRoom = GroupChatRoom.createRoom(gathering);

--- a/src/main/java/com/runto/domain/chat/config/SocketInterceptor.java
+++ b/src/main/java/com/runto/domain/chat/config/SocketInterceptor.java
@@ -1,0 +1,37 @@
+package com.runto.domain.chat.config;
+
+import com.runto.global.security.util.JWTUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class SocketInterceptor implements HandshakeInterceptor {
+    private final JWTUtil jwtUtil;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        HttpServletRequest req = ((ServletServerHttpRequest)request).getServletRequest();
+
+        String token = Optional.ofNullable(jwtUtil.extractAccessToken(req))
+                .orElse(jwtUtil.oauthAccessToken(req));
+
+        attributes.put("Authorization",token);
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/src/main/java/com/runto/domain/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/runto/domain/chat/config/WebSocketConfig.java
@@ -1,18 +1,40 @@
 package com.runto.domain.chat.config;
 
+import com.runto.global.security.detail.CustomUserDetails;
+import com.runto.global.security.dto.UserDetailsDTO;
+import com.runto.global.security.util.JWTUtil;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import java.util.List;
+
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketConfig.class);
+    private final JWTUtil jwtUtil;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -44,4 +66,58 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         retryTemplate.setBackOffPolicy(backOffPolicy);
         return retryTemplate;
     }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+                String authHeader = String.valueOf(accessor.getNativeHeader("Authorization"));
+
+                StompCommand command = accessor.getCommand();
+
+                if (command.equals(StompCommand.UNSUBSCRIBE) || command.equals(StompCommand.MESSAGE) ||
+                command.equals(StompCommand.CONNECTED) || command.equals(StompCommand.SEND)){
+                    return message;
+                }else if (command.equals(StompCommand.ERROR)){
+                    log.error("STOMP ERROR");
+                    throw new RuntimeException("STOMP 에러");
+                }
+
+                if (authHeader == null){
+                    log.error("Authorization Header 가 존재하지 않습니다");
+                    throw new RuntimeException("헤더가 존재하지 않음");
+                }
+
+                String token = "";
+                String authHeaderStr = authHeader.replace("[","").replace("]","");
+                if (authHeaderStr.startsWith("Bearer ")) {
+                    token = authHeaderStr.replace("Bearer ", "");
+                } else {
+                    log.error("Authorization 헤더 형식이 틀립니다. : {}", authHeaderStr);
+                    throw new RuntimeException("올바르지 않은 헤더 형식");
+                }
+
+                try {
+                    Long userId = jwtUtil.getId(token);
+                    String username = jwtUtil.getUsername(token);
+                    String role = jwtUtil.getRole(token);
+
+                    CustomUserDetails userDetails = new CustomUserDetails(new UserDetailsDTO(userId,username,null,null,null,null,role));
+                    UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, List.of(new SimpleGrantedAuthority(role)));
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+                } catch (Exception e) {
+                    log.error("JWT 처리 중 오류 발생: {}", e.getMessage());
+                    throw new RuntimeException("유효하지 않은 토큰입니다.");
+                }
+
+                return message;
+            }
+        });
+    }
+
+
 }

--- a/src/main/java/com/runto/domain/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/runto/domain/chat/config/WebSocketConfig.java
@@ -41,6 +41,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
                 .setAllowedOrigins("http://localhost:3000")
 //                .setAllowedOrigins("https://runto.vercel.app/")
+                .addInterceptors(new SocketInterceptor(jwtUtil))
                 .withSockJS()
                 .setClientLibraryUrl("https://cdn.jsdelivr.net/sockjs/1.1.4/sockjs.min.js");
     }

--- a/src/main/java/com/runto/domain/chat/dao/DirectChatRoomRepositoryCustom.java
+++ b/src/main/java/com/runto/domain/chat/dao/DirectChatRoomRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.runto.domain.chat.dao;
 
-import com.runto.domain.chat.dto.DirectChatRoomResponse;
+import com.runto.domain.chat.dto.ChatRoomResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface DirectChatRoomRepositoryCustom {
 
-    Slice<DirectChatRoomResponse> getChatRooms(Long userId, Pageable pageable);
+    Slice<ChatRoomResponse> getChatRooms(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/runto/domain/chat/dao/DirectChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/runto/domain/chat/dao/DirectChatRoomRepositoryCustomImpl.java
@@ -4,9 +4,8 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.runto.domain.chat.domain.DirectChatRoom;
 import com.runto.domain.chat.domain.QDirectChatRoom;
-import com.runto.domain.chat.dto.DirectChatRoomResponse;
+import com.runto.domain.chat.dto.ChatRoomResponse;
 import com.runto.domain.user.domain.QUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,12 +22,12 @@ public class DirectChatRoomRepositoryCustomImpl implements DirectChatRoomReposit
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<DirectChatRoomResponse> getChatRooms(Long userId, Pageable pageable) {
+    public Slice<ChatRoomResponse> getChatRooms(Long userId, Pageable pageable) {
         QDirectChatRoom d = QDirectChatRoom.directChatRoom;
         QUser u = QUser.user;
 
-        List<DirectChatRoomResponse> chatRoomList = jpaQueryFactory
-                .select(Projections.constructor(DirectChatRoomResponse.class,
+        List<ChatRoomResponse> chatRoomList = jpaQueryFactory
+                .select(Projections.constructor(ChatRoomResponse.class,
                         d.id,
                         JPAExpressions.select(u.name)
                                 .from(u)
@@ -47,7 +46,7 @@ public class DirectChatRoomRepositoryCustomImpl implements DirectChatRoomReposit
         return new SliceImpl<>(chatRoomList, pageable, hasNextPage(pageable, chatRoomList));
     }
 
-    private boolean hasNextPage(Pageable pageable, List<DirectChatRoomResponse> chatRoomList){
+    private boolean hasNextPage(Pageable pageable, List<ChatRoomResponse> chatRoomList){
         if (chatRoomList.size() > pageable.getPageSize()){
             chatRoomList.remove(chatRoomList.size() - 1);
             return true;

--- a/src/main/java/com/runto/domain/chat/dao/DirectMessageRepository.java
+++ b/src/main/java/com/runto/domain/chat/dao/DirectMessageRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.repository.Query;
 
 import java.time.LocalDateTime;
 
-public interface DirectMessageRepository extends MongoRepository<DirectChatContent,Long> {
+public interface DirectMessageRepository extends MongoRepository<DirectChatContent,String> {
     @Query("{'room_id' : ?0, 'status': 'SENT', 'timestamp' :  {$gte : ?1} }")
     Slice<DirectChatContent> findDirectChatContent(Long roomId, LocalDateTime daysAgo, Pageable pageable);
 }

--- a/src/main/java/com/runto/domain/chat/dao/GroupChatRoomRepository.java
+++ b/src/main/java/com/runto/domain/chat/dao/GroupChatRoomRepository.java
@@ -1,8 +1,22 @@
 package com.runto.domain.chat.dao;
 
 import com.runto.domain.chat.domain.GroupChatRoom;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupChatRoomRepository extends JpaRepository<GroupChatRoom,Long> {
 
+    @Query("select gc from GroupChatRoom gc " +
+            "where gc.gathering.id = :gid")
+    GroupChatRoom findByGatheringId(@Param("gid") Long gatheringId);
+
+    @Query("select gcr " +
+            "from GroupChatRoom gcr " +
+            "join fetch GroupChatRoomUser gu on gu.groupChatRoom.id = gcr.id " +
+            "join fetch Gathering g on gcr.gathering.id = g.id " +
+            "where gu.user.id = :id ")
+    Slice<GroupChatRoom> findGroupChatRoomById(Long id, Pageable pageable);
 }

--- a/src/main/java/com/runto/domain/chat/dao/GroupMessageRepository.java
+++ b/src/main/java/com/runto/domain/chat/dao/GroupMessageRepository.java
@@ -1,0 +1,14 @@
+package com.runto.domain.chat.dao;
+
+import com.runto.domain.chat.domain.GroupChatContent;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.time.LocalDateTime;
+
+public interface GroupMessageRepository extends MongoRepository<GroupChatContent,String> {
+    @Query("{'room_id' : ?0, 'status': 'SENT', 'timestamp' :  {$gte : ?1} }")
+    Slice<GroupChatContent> findGroupChatContent(Long roomId, LocalDateTime daysAgo, Pageable pageable);
+}

--- a/src/main/java/com/runto/domain/chat/domain/GroupChatContent.java
+++ b/src/main/java/com/runto/domain/chat/domain/GroupChatContent.java
@@ -1,0 +1,53 @@
+package com.runto.domain.chat.domain;
+
+import com.runto.domain.chat.dto.MessageQueueDTO;
+import com.runto.domain.chat.type.MessageStatus;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "group_chat")
+public class GroupChatContent {
+    @Id
+    private String id;
+
+    @Field("room_id")
+    @Indexed
+    private Long roomId;
+
+    @Field("sender_id")
+    private Long senderId;
+
+    private String content;
+
+    private LocalDateTime timestamp;
+
+    @Field("status")
+    private MessageStatus messageStatus;
+
+    public static GroupChatContent of(MessageQueueDTO messageQueueDTO){
+        LocalDateTime timestamp = LocalDateTime.parse(messageQueueDTO.getTimestamp(), DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return GroupChatContent.builder()
+                .roomId(messageQueueDTO.getRoomId())
+                .senderId(messageQueueDTO.getSenderId())
+                .content(messageQueueDTO.getContent())
+                .timestamp(timestamp)
+                .messageStatus(MessageStatus.SENT).build();
+    }
+
+    public void changeStatusToFailed(){
+        this.messageStatus = MessageStatus.FAILED;
+    }
+}

--- a/src/main/java/com/runto/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/com/runto/domain/chat/dto/ChatResponse.java
@@ -10,8 +10,8 @@ import org.springframework.data.domain.Slice;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DirectChatResponse {
+public class ChatResponse {
+
     private Long roomId;
     private Slice<MessageResponse> messages;
-
 }

--- a/src/main/java/com/runto/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/runto/domain/chat/dto/ChatRoomResponse.java
@@ -1,18 +1,21 @@
 package com.runto.domain.chat.dto;
 
+import com.runto.domain.chat.domain.GroupChatRoom;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DirectChatRoomResponse {
+public class ChatRoomResponse {
 
     private Long roomId;
-    private String otherName;
-    private String otherProfileImage;
+    private String name;
+    private String profileImage;
 
 }
 

--- a/src/main/java/com/runto/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/runto/domain/chat/dto/ChatRoomResponse.java
@@ -17,5 +17,11 @@ public class ChatRoomResponse {
     private String name;
     private String profileImage;
 
+    public static ChatRoomResponse fromGroupChatRoom(GroupChatRoom groupChatRoom){
+        return ChatRoomResponse.builder()
+                .roomId(groupChatRoom.getId())
+                .name(groupChatRoom.getGathering().getTitle())
+                .profileImage(groupChatRoom.getGathering().getThumbnailUrl()).build();
+    }
 }
 

--- a/src/main/java/com/runto/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/com/runto/domain/chat/dto/MessageResponse.java
@@ -1,6 +1,7 @@
 package com.runto.domain.chat.dto;
 
 import com.runto.domain.chat.domain.DirectChatContent;
+import com.runto.domain.chat.domain.GroupChatContent;
 import com.runto.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +36,16 @@ public class MessageResponse {
                 .senderProfileImageUrl(user.getProfileImageUrl())
                 .content(directChatContent.getContent())
                 .timestamp(directChatContent.getTimestamp().toString())
+                .build();
+    }
+
+    public static MessageResponse of(GroupChatContent groupChatContent, User user){
+        return MessageResponse.builder()
+                .senderId(groupChatContent.getSenderId())
+                .senderName(user.getName())
+                .senderProfileImageUrl(user.getProfileImageUrl())
+                .content(groupChatContent.getContent())
+                .timestamp(groupChatContent.getTimestamp().toString())
                 .build();
     }
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
@@ -20,4 +20,9 @@ public interface GatheringMemberRepository extends JpaRepository<GatheringMember
             @Param("gathering_id") Long gatheringId, Pageable pageable);
 
     List<GatheringMember> findGatheringMembersByGatheringId(Long gatheringId);
+
+    @Query("select count(gm) > 0 from GatheringMember gm " +
+            "where gm.gathering.id = :gathering_id and gm.user.id =:userId")
+    boolean existsGatheringMemberByGathering(@Param("gathering_id") Long gatheringId,
+                                     @Param("user_id") Long userId);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
@@ -23,6 +23,6 @@ public interface GatheringMemberRepository extends JpaRepository<GatheringMember
 
     @Query("select count(gm) > 0 from GatheringMember gm " +
             "where gm.gathering.id = :gathering_id and gm.user.id =:userId")
-    boolean existsGatheringMemberByGathering(@Param("gathering_id") Long gatheringId,
+    boolean existsGatheringMemberByGatheringIdAndUserId(@Param("gathering_id") Long gatheringId,
                                      @Param("user_id") Long userId);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
@@ -11,5 +11,4 @@ import java.util.Optional;
 @Repository
 public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringRepositoryCustom, GatheringMgmtRepositoryCustom {
 
-    Optional<Gathering> findGatheringById(Long id);
 }

--- a/src/main/java/com/runto/global/exception/ErrorCode.java
+++ b/src/main/java/com/runto/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     // 모임글 & 이벤트 관련
     GATHERING_NOT_FOUND(NOT_FOUND, "존재하지 않는 모임글입니다."),
     GATHERING_REPORTED(FORBIDDEN, "신고당한 모임글입니다."),
+    GATHERING_MEMBER_NOT_FOUND(NOT_FOUND, "모임에 참여중이지 않은 사용자입니다."),
     EVENT_GATHERING_NOT_APPROVED_ONLY_ORGANIZER_CAN_VIEW(FORBIDDEN, "승인상태가 아닌 이벤트모임은 주최자 본인만 볼 수 있습니다."),
     EVENT_GATHERING_NOT_FOUND(NOT_FOUND, "이벤트 모임이지만, 이벤트에 대한 정보가 존재하지 않습니다. 관리자에게 문의해주세요."),
     GENERAL_MAX_NUMBER(BAD_REQUEST, "일반 모임의 최대 인원은 2명에서 10명 사이여야 합니다."),
@@ -43,7 +44,7 @@ public enum ErrorCode {
     INVALID_APPOINTMENT_TOO_SOON(BAD_REQUEST, "약속 날짜는 현재 기준으로 최소 6시간 이후여야 합니다."),
     INVALID_DEADLINE_APPOINTMENT_INTERVAL(BAD_REQUEST, "약속 날짜는 마감 날짜와 최소 2시간의 차이가 있어야 합니다."),
 
-    // 채팅관련,
+    // 채팅관련
     CHATROOM_ALREADY_EXIST(CONFLICT, "이미 존재하는 채팅방입니다."),
     CHATROOM_NOT_FOUND(NOT_FOUND, "존재하지 않는 채팅방입니다."),
     CHATROOM_ALREADY_JOINED(BAD_REQUEST, "이미 참여중인 채팅방입니다."),

--- a/src/test/java/com/runto/domain/chat/application/GroupChatServiceTest.java
+++ b/src/test/java/com/runto/domain/chat/application/GroupChatServiceTest.java
@@ -97,7 +97,7 @@ class GroupChatServiceTest {
         when(groupChatRoomUserRepository.existsByGroupChatRoomAndUser(any(GroupChatRoom.class), any(User.class))).thenReturn(false);
         when(groupChatRoomUserRepository.findById(any(Long.class))).thenReturn(Optional.of(groupChatRoomUser));
 
-        groupChatService.joinGroupChatRoom(user2, groupChatRoom);
+//        groupChatService.joinGroupChatRoom(user2, groupChatRoom);
 
         //then
         verify(groupChatRoomRepository).findById(any(Long.class));


### PR DESCRIPTION


## 🔎 작업 내용
그룹 채팅을 생성합니다. ( id 라는 파라미터로 gatheringId 를 받습니다)
그룹 채팅에 참가합니다. ( id 라는 파라미터로 gatheringId 를 받습니다)
내가 참가한 그룹 채팅 목록을 조회합니다. (page_num)
그룹 채팅방 목록에서 하나의 채팅방을 조회합니다. (room_id, page_num)
그룹 채팅방에 채팅을 전송합니다. ( 현재 웹소켓, HTTP 요청 둘다 있는데 HTTP는 테스트용입니다)

ProducerController, ProducerService 에서 클라이언트의 메시지를 받고, 브로커로 보내는 로직을 구현
ConsumerService 에서 메시지를 받고 처리합니다.

WebSocketConfig 에 인터셉터를 하나 추가했는데
@MessageMapping (웹소켓)에서는 기본적으로 @AuthenticationPrincipal CustomUserDetails 를 사용할 수 없다고 합니다.
그래서 해당 코드를 추가해 웹소켓에서도 사용자 인증 정보를 사용하기 위한 것이라고 보면 됩니다.
근데 아직 실제로 웹소켓 테스트를 안해봐서 될지 안될지는 잘 모르겠습니다! 안되면 추후에 바꿀 수도 있습니다.

이외에 기존에 Direct~~ 로 되어있던 dto들을 공통으로 사용하기위해 이름들을 바꿨습니다.

## 이미지 첨부 (선)


<br/>

## 🔧 리뷰 요구사항
> 그룹 채팅 생성 참가가 모임 생성, 참가랑 같이 되게 가능할까요? gathering_id가 필요한데 



<br/>
