### PR TITLE
✨Feat( #138):  상세조회 조회수 기능 구현 &  조회수 / 참가  동시성테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok'
 
     // 인증관련
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -53,10 +53,14 @@ public class GatheringController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("gathering_id") Long gatheringId) {
 
-        gatheringService.hitGathering(userDetails.getUserId(), gatheringId);
+        // 접근 가능한지 먼저 알아야함
+        GatheringDetailResponse gatheringDetail = gatheringService
+                .getGatheringDetail(userDetails.getUserId(), gatheringId);
 
-        return ResponseEntity.ok(gatheringService.
-                getGatheringDetail(userDetails.getUserId(), gatheringId));
+        gatheringDetail.getContent()
+                .addMyHit(gatheringService.hitGathering(userDetails.getUserId(), gatheringId));
+
+        return ResponseEntity.ok(gatheringDetail);
     }
 
     @Operation(summary = "모임목록 조회 [일반모임, 이벤트모임]")

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -10,7 +10,6 @@ import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.gathering.type.EventRequestStatus;
 import com.runto.domain.gathering.type.GatheringType;
 import com.runto.domain.image.application.ImageService;
-import com.runto.domain.image.application.GatheringViewCountService;
 import com.runto.domain.image.domain.GatheringImage;
 import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUrlDto;
@@ -57,7 +56,6 @@ public class GatheringService {
     private final GatheringMemberRepository gatheringMemberRepository;
     private final GatheringMemberCountRepository gatheringMemberCountRepository;
     private final GatheringViewRecordRepository gatheringViewRecordRepository;
-    private final GatheringViewCountService gatheringViewCountService;
 
 
     // TODO moveImageProcess 에러 해결되면 주석 풀기

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -4,12 +4,12 @@ package com.runto.domain.gathering.application;
 import com.runto.domain.gathering.dao.*;
 import com.runto.domain.gathering.domain.Gathering;
 import com.runto.domain.gathering.domain.GatheringMemberCount;
-import com.runto.domain.gathering.domain.GatheringViewRecord;
 import com.runto.domain.gathering.dto.*;
 import com.runto.domain.gathering.exception.GatheringException;
 import com.runto.domain.gathering.type.EventRequestStatus;
 import com.runto.domain.gathering.type.GatheringType;
 import com.runto.domain.image.application.ImageService;
+import com.runto.domain.image.application.GatheringViewCountService;
 import com.runto.domain.image.domain.GatheringImage;
 import com.runto.domain.image.dto.ImageRegisterResponse;
 import com.runto.domain.image.dto.ImageUrlDto;
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -42,7 +41,6 @@ import static com.runto.domain.gathering.type.GatheringType.EVENT;
 import static com.runto.domain.gathering.type.GatheringType.GENERAL;
 import static com.runto.domain.user.type.UserStatus.ACTIVE;
 import static com.runto.global.exception.ErrorCode.*;
-import static org.springframework.transaction.annotation.Propagation.*;
 
 @Slf4j
 @Transactional(readOnly = true)
@@ -58,6 +56,7 @@ public class GatheringService {
     private final GatheringMemberRepository gatheringMemberRepository;
     private final GatheringMemberCountRepository gatheringMemberCountRepository;
     private final GatheringViewRecordRepository gatheringViewRecordRepository;
+    private final GatheringViewCountService gatheringViewCountService;
 
 
     // TODO moveImageProcess 에러 해결되면 주석 풀기
@@ -166,13 +165,9 @@ public class GatheringService {
      * <p>
      * 낙관적 락
      * 충돌이 적게 발생하고 데이터의 일관성, 정합성보다는 성능이 중요시될 때
-     *
      */
     // 왜 dto 로 바로 받는 방식으로 수정했는지는 pr 참고 (관련이슈 #110)
-    // TODO: 조회수 로직 추가
     public GatheringDetailResponse getGatheringDetail(Long userId, Long gatheringId) {
-
-        //hitGathering(userId, gatheringId);
 
         GatheringDetailResponse response = gatheringRepository
                 .getGatheringDetailWithUserParticipation(gatheringId, userId);
@@ -180,28 +175,25 @@ public class GatheringService {
         validateGatheringAccessibility(userId, response);
 
         return response;
-
     }
 
 
-    // QUESTION: 이걸 new 로 잡았는데, 얘도 read_only 로 된다.
-    // Connection is read-only. Queries leading to data modification are not allowed
-    // 조회 수 증가를 했을 시, 나중에 dto 꺼내올때 그게 반영된 모임이어야함
-    //@Transactional(readOnly = false, propagation = REQUIRES_NEW)
+    /**
+     * QUESTION: 이걸 readOnly = false, propagation = REQUIRES_NEW 로 잡고,
+     *  getGatheringDetail 안에서 호출했더니, 얘도 read_only 로 된다.
+     *  Connection is read-only. Queries leading to data modification are not allowed
+     * <p>
+     * 컨트롤러에서 별도로  getGatheringDetail 와는 별도로 호출해서, 수정관련 트랜잭션은 짧게 끝내기
+     */
     @Transactional
     public void hitGathering(Long userId, Long gatheringId) {
         if (gatheringViewRecordRepository.existsByGatheringIdAndUserId(gatheringId, userId))
             return;
 
-        // 문제는 조회할 Gathering 이 문제임 (동시성제어 필요)
-        Gathering gathering = gatheringRepository.findById(gatheringId)
+        Gathering gathering = gatheringRepository.findByIdWithOptimisticLock(gatheringId)
                 .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
 
-        gatheringViewRecordRepository
-                .save(new GatheringViewRecord(gatheringId, userId));
-
-        gathering.increaseHits();
-        //gatheringRepository.flush();
+        gatheringViewCountService.addGatheringViewRecord(userId, gathering);
     }
 
     private void validateGatheringAccessibility(Long userId, GatheringDetailResponse response) {
@@ -408,47 +400,38 @@ public class GatheringService {
 
     // TODO: 나중에 주석 지우기
     // TODO: 동시성 테스트 및 수정
-    @Transactional
-    public ParticipateGatheringResponse participateGathering(Long userId, Long gatheringId) {
 
-        // [참가/취소] 에 비관락을 써보려는 이유
-        // 주로 데이터 충돌이 자주 발생하거나 데이터의 일관성이 중요한 상황에서 사용
-        // -> 일단 충돌이 자주 일어난다는 기준이 뭔지 잘 모르겠음
-        // -> 데이터의 일관성? 은 중요함 , 순서도 중요하고
+    // [참가/취소] 에 비관락을 써보려는 이유
+    // 주로 데이터 충돌이 자주 발생하거나 데이터의 일관성이 중요한 상황에서 사용
+    // -> 일단 충돌이 자주 일어난다는 기준이 뭔지 잘 모르겠음
+    // -> 데이터의 일관성? 은 중요함 , 순서도 중요하고
 
 
-        // [GatheringMemberCount 이 없을때] -> [] 은 Gathering이 비관락에 걸리고 있는 상황일때
-        //  0. 인증객체에서 받아온 userId로 user 엔티티 꺼내오기 (정상유저인지 등 확인, 나중에 GatheringMember 에 넣는 용)
-        //  1. GatheringMember 에 내가 있는지 확인 exist  -> 있으면 바로 예외터뜨리기
-        // [2]. Gathering 을 비관락을 걸어서 들고온다? (수정하는 작업이니까, PESSIMISTIC_WRITE)
-        // [3]. Gathering 에서의 현재인원수 체크 -> 전체인원수 이상이면 -> 바로 예외터뜨리기
-        // [4]. GathringMember를 만들어서 Gathering에 넣기 & 현재인원수 ++; -> save
-        // 근데 이 방식은... 흠... 일단 모임이, 목록조회, 상세조회 등 조회가 잦다고 생각하면,
-        // PESSIMISTIC_WRITE 로 걸면 다른 트랜잭션에서 읽기도 안되니까, 성능상 문제가..?
-        // 그리고 [s-lock] vs [x-lock] 과의 충돌 상황이 더 많이 벌어지지 않을까?
+    // [GatheringMemberCount 이 없을때] -> [] 은 Gathering이 비관락에 걸리고 있는 상황일때
+    //  0. 인증객체에서 받아온 userId로 user 엔티티 꺼내오기 (정상유저인지 등 확인, 나중에 GatheringMember 에 넣는 용)
+    //  1. GatheringMember 에 내가 있는지 확인 exist  -> 있으면 바로 예외터뜨리기
+    // [2]. Gathering 을 비관락을 걸어서 들고온다? (수정하는 작업이니까, PESSIMISTIC_WRITE)
+    // [3]. Gathering 에서의 현재인원수 체크 -> 전체인원수 이상이면 -> 바로 예외터뜨리기
+    // [4]. GathringMember를 만들어서 Gathering에 넣기 & 현재인원수 ++; -> save
+    // 근데 이 방식은... 흠... 일단 모임이, 목록조회, 상세조회 등 조회가 잦다고 생각하면,
+    // PESSIMISTIC_WRITE 로 걸면 다른 트랜잭션에서 읽기도 안되니까, 성능상 문제가..?
+    // 그리고 [s-lock] vs [x-lock] 과의 충돌 상황이 더 많이 벌어지지 않을까?
 
 // =========================================================================================
-        // [GatheringMemberCount 이 있을 때] ->  [] 은 NumberGathering lock 에 걸리고 있는 상황일때, []] 는 Gathering 도 lock 상태일때 (x- lock)
-        //  0. 인증객체에서 받아온 userId로 user 엔티티 꺼내오기 (정상유저인지 등 확인, 나중에 GatheringMember 에 넣는 용)
-        //  1. GatheringMember 에 내가 있는지 확인 exist  -> 있으면 바로 예외터뜨리기
-        //  2. NumberGathering 만 별도로 비관락을 걸어서 들고온다. (수정하는 작업이니까, PESSIMISTIC_WRITE)
+    // [GatheringMemberCount 이 있을 때] ->  [] 은 NumberGathering lock 에 걸리고 있는 상황일때, []] 는 Gathering 도 lock 상태일때 (x- lock)
+    //  0. 인증객체에서 받아온 userId로 user 엔티티 꺼내오기 (정상유저인지 등 확인, 나중에 GatheringMember 에 넣는 용)
+    //  1. GatheringMember 에 내가 있는지 확인 exist  -> 있으면 바로 예외터뜨리기
+    //  2. NumberGathering 만 별도로 비관락을 걸어서 들고온다. (수정하는 작업이니까, PESSIMISTIC_WRITE)
 
-        // ---- 이때부터는 또 다른 참가/취소 요청 사용자는 기다려야함
-        // [3]. NumberGathering 에 있는 현재인원수 체크 -> 전체인원수 이상이면 -> 바로 예외터뜨리기
-        // [4]. NumberGathering 에 있는 현재인원수 업데이트
-        // [5]]. Gathering 꺼내오기 (x - 락) - 이 때 사실 이 작업이 끝나기 전까진  블로킹 당할텐데.. 흠... 뭔 차이지..
-        // [6]]. GathringMember를 만들어서 Gathering에 넣기 & 현재인원수++; -> save
-
-        //  로직 시작 ================================================================
+    // ---- 이때부터는 또 다른 참가/취소 요청 사용자는 기다려야함
+    // [3]. NumberGathering 에 있는 현재인원수 체크 -> 전체인원수 이상이면 -> 바로 예외터뜨리기
+    // [4]. NumberGathering 에 있는 현재인원수 업데이트
+    // [5]]. Gathering 꺼내오기 (x - 락) - 이 때 사실 이 작업이 끝나기 전까진  블로킹 당할텐데.. 흠... 뭔 차이지..
+    // [6]]. GathringMember를 만들어서 Gathering에 넣기 & 현재인원수++; -> save
 
 
-        // 비관락을 걸기 전까지의 로직에서 최대한 x-lock 으로 들고 오는 일은 없게끔 하려고했는데,
-        // user 개인은 초반부터 x - lock 걸려도 크게 상관없겠지 했는데,
-        // 하고 생각해보니, user 의 경우 일반목록조회 시에도 프로필 이미지때문에, 패치조인해서, 사용되고 있었다.
-        // gathering 에 x-lock 이 걸리는 시간을 짧게 하려는 거에 집중해버려서, 멤버들의 프로필이미지를 생각치 못하고 있었다.
-        // 다른 트랜잭션들에서 비관락때문에 대기타면서 user 를 x - lock 으로 붙잡고 있는 것보다는
-        // 구성원 멤버로 추가(addMember)를 할 때, user 엔티티를 꺼내는게 낫지 않을까? 싶었다.
-        // 어차피 파라미터로 들어오는 userId는 인증객체로 부터 뽑아온 userId 니까 존재하는 user 인건 보장이 되어있기때문에.. 초반부터 꺼낼 필요가 없을 듯한..
+    @Transactional
+    public ParticipateGatheringResponse participateGathering(Long userId, Long gatheringId) {
 
         // 이미 참가중인지 확인
         if (gatheringMemberRepository.existsByGatheringIdAndUserId(gatheringId, userId)) {
@@ -456,24 +439,27 @@ public class GatheringService {
         }
 
         // gatheringMemberCount 를 비관락으로 가져옴
-        GatheringMemberCount memberCount = gatheringMemberCountRepository.findByGatheringId(gatheringId)
+        GatheringMemberCount memberCount = gatheringMemberCountRepository.findByGatheringIdWithPessimisticLock(gatheringId)
                 .orElseThrow(() -> new GatheringException(GATHERING_MEMBER_COUNT_NOT_FOUND));
 
         if (memberCount.getCurrentNumber() >= memberCount.getMaxNumber()) {
             throw new GatheringException(GATHERING_MEMBER_CAPACITY_EXCEEDED);
         }
 
-        // 먼저 참가인원 증가
+        // 참가인원 증가
         memberCount.increaseCurrentMember();
 
-        // x-lock
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         Gathering gathering = gatheringRepository.findGatheringWithEventById(gatheringId)
                 .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
 
+        log.info("gathering.getCurrentNumber() ={} ",gathering.getCurrentNumber());
         gathering.addMember(user, PARTICIPANT);
+
+        gathering.updateCurrentNumber(memberCount.getCurrentNumber());
+        //gathering.increaseCurrentNumber(); //동시성 제어 X
 
         return ParticipateGatheringResponse.from(gathering);
     }
@@ -486,10 +472,10 @@ public class GatheringService {
         }
 
         // gatheringMemberCount 를 비관락으로 가져옴
-        GatheringMemberCount memberCount = gatheringMemberCountRepository.findByGatheringId(gatheringId)
+        GatheringMemberCount memberCount = gatheringMemberCountRepository
+                .findByGatheringIdWithPessimisticLock(gatheringId)
                 .orElseThrow(() -> new GatheringException(GATHERING_MEMBER_COUNT_NOT_FOUND));
 
-        // gathering  x-lock
         Gathering gathering = gatheringRepository.findGatheringWithEventById(gatheringId)
                 .orElseThrow(() -> new GatheringException(GATHERING_NOT_FOUND));
 
@@ -497,7 +483,7 @@ public class GatheringService {
 
         gatheringMemberRepository.deleteByGatheringIdAndUserId(gatheringId, userId);
         memberCount.decreaseCurrentMember();
-        gathering.decreaseCurrentNumber();
+        gathering.updateCurrentNumber(memberCount.getCurrentNumber());
     }
 
     private void validateCancelParticipate(Long userId, Gathering gathering) {

--- a/src/main/java/com/runto/domain/gathering/application/GatheringService.java
+++ b/src/main/java/com/runto/domain/gathering/application/GatheringService.java
@@ -106,6 +106,8 @@ public class GatheringService {
 
         Gathering gathering = request.toEntity(user, type);
         gathering.addMember(user, ORGANIZER);
+        gathering.updateCurrentNumber(1);
+
         addContentImages(request.getImageRegisterResponse(), gathering);
 
         return gathering;

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberCountRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberCountRepository.java
@@ -4,14 +4,22 @@ import com.runto.domain.gathering.domain.GatheringMemberCount;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Repository
 public interface GatheringMemberCountRepository extends JpaRepository<GatheringMemberCount, Long> {
 
+    // 별도로 @Transactional 안 붙이면 테스트코드에서, Query requires transaction be in progress, but no transaction is known to be in progress 가 떴음
+    @Transactional
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<GatheringMemberCount> findByGatheringId(Long gatheringId);
+    @Query("select gmc from GatheringMemberCount gmc " +
+            " where gmc.gathering.id = :gatheringId ")
+    Optional<GatheringMemberCount> findByGatheringIdWithPessimisticLock(
+            @Param("gatheringId") Long gatheringId);
 
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringMemberRepository.java
@@ -31,4 +31,6 @@ public interface GatheringMemberRepository extends JpaRepository<GatheringMember
     boolean existsByGatheringIdAndUserId(Long GatheringId, Long userId);
 
     void deleteByGatheringIdAndUserId(Long gatheringId, Long userId);
+
+    int countByGatheringId(Long GatheringId);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringRepository.java
@@ -3,7 +3,9 @@ package com.runto.domain.gathering.dao;
 
 import com.runto.domain.admin.dao.GatheringMgmtRepositoryCustom;
 import com.runto.domain.gathering.domain.Gathering;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,11 +15,23 @@ import java.util.Optional;
 @Repository
 public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringRepositoryCustom, GatheringMgmtRepositoryCustom {
 
-    Optional<Gathering> findGatheringById(Long id);
-
     @Query("select g from Gathering g " +
             " left join fetch g.eventGathering " +
             " where g.id = :gatheringId ")
     Optional<Gathering> findGatheringWithEventById(@Param("gatheringId") Long gatheringId);
 
+
+
+    // 찾았던 것에서는 PESSIMISTIC_READ 의 경우 쓰기가 막혀있다고 했었는데, 직접 적용해보니, 수정이 되기는 한다. (동시성제어가 안될뿐)
+    // 결국 읽어올 때만 다른 트랜잭션이 동시에 읽을 수 없도록 하는 것 같다
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select g from Gathering g " +
+            " left join fetch g.eventGathering " +
+            " where g.id = :gatheringId ")
+    Optional<Gathering> findByIdWithPessimisticLock(@Param("gatheringId") Long gatheringId);
+
+
+//    @Modifying
+//    @Query("UPDATE Gathering g SET g.hits = g.hits + 1 WHERE g.id = :gatheringId")
+//    void increaseHits(@Param("gatheringId") Long gatheringId);
 }

--- a/src/main/java/com/runto/domain/gathering/dao/GatheringViewRecordRepository.java
+++ b/src/main/java/com/runto/domain/gathering/dao/GatheringViewRecordRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface GatheringViewRecordRepository extends JpaRepository<GatheringViewRecord, Long> {
 
     boolean existsByGatheringIdAndUserId(Long gatheringId, Long userId);
+
+    int countByGatheringId(Long GatheringId);
 }

--- a/src/main/java/com/runto/domain/gathering/domain/GatheringViewRecord.java
+++ b/src/main/java/com/runto/domain/gathering/domain/GatheringViewRecord.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -23,8 +24,10 @@ public class GatheringViewRecord {
     @Column(name = "view_record_id")
     private Long id;
 
-    // ID 간접참조로 설정하였음
-    private Long gatheringId;
+
+    @JoinColumn(name = "gathering_id")
+    @ManyToOne(fetch = LAZY)
+    private Gathering gathering;
 
     private Long userId;
 
@@ -32,8 +35,8 @@ public class GatheringViewRecord {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public GatheringViewRecord(Long gatheringId, Long userId) {
-        this.gatheringId = gatheringId;
+    public GatheringViewRecord(Gathering gathering, Long userId) {
+        this.gathering = gathering;
         this.userId = userId;
     }
 }

--- a/src/main/java/com/runto/domain/gathering/dto/GatheringDetailContentResponse.java
+++ b/src/main/java/com/runto/domain/gathering/dto/GatheringDetailContentResponse.java
@@ -49,4 +49,8 @@ public class GatheringDetailContentResponse { // 이벤트 상세조회 시에�
 
     private EventRequestStatus eventRequestStatus; // 일반모임이면 해당 값은 null
 
+    public void addMyHit(boolean myNewHit) {
+        if(myNewHit) hits++;
+    }
+
 }

--- a/src/test/java/com/runto/domain/gathering/application/GatheringServiceLockTest.java
+++ b/src/test/java/com/runto/domain/gathering/application/GatheringServiceLockTest.java
@@ -1,0 +1,219 @@
+package com.runto.domain.gathering.application;
+
+import com.runto.domain.gathering.application.GatheringService;
+import com.runto.domain.gathering.dao.GatheringMemberCountRepository;
+import com.runto.domain.gathering.dao.GatheringMemberRepository;
+import com.runto.domain.gathering.dao.GatheringRepository;
+import com.runto.domain.gathering.dao.GatheringViewRecordRepository;
+import com.runto.domain.gathering.domain.*;
+import com.runto.domain.gathering.exception.GatheringException;
+import com.runto.domain.gathering.type.GoalDistance;
+import com.runto.domain.gathering.type.RunningConcept;
+import com.runto.domain.user.dao.UserRepository;
+import com.runto.domain.user.domain.LocalAccount;
+import com.runto.domain.user.domain.User;
+import com.runto.domain.user.type.UserRole;
+import com.runto.global.config.QueryDSLConfig;
+import groovy.util.logging.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.runto.domain.gathering.type.GatheringMemberRole.ORGANIZER;
+import static com.runto.domain.gathering.type.GatheringStatus.NORMAL;
+import static com.runto.domain.gathering.type.GatheringType.GENERAL;
+import static com.runto.domain.user.type.Gender.MAN;
+import static com.runto.domain.user.type.UserStatus.ACTIVE;
+import static com.runto.global.exception.ErrorCode.GATHERING_MEMBER_COUNT_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+//@Rollback(value = false)
+@Slf4j
+@Import(QueryDSLConfig.class)
+@ActiveProfiles("local") // test 로 잡으면 빈 생성 문제 있음
+@SpringBootTest
+class GatheringServiceLockTest {
+
+//    @Autowired
+//    private GatheringViewCountService gatheringViewCountService;
+
+    @Autowired
+    private GatheringService gatheringService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GatheringRepository gatheringRepository;
+
+    @Autowired
+    private GatheringViewRecordRepository gatheringViewRecordRepository;
+
+    @Autowired
+    private GatheringMemberRepository gatheringMemberRepository;
+
+    @Autowired
+    private GatheringMemberCountRepository gatheringMemberCountRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    private List<User> users;
+    private Gathering gathering;
+    private GatheringMemberCount gatheringMemberCount;
+
+    @BeforeEach
+    public void init() {
+        users = new ArrayList<>();
+
+
+        for (int i = 1; i <= 100; i++) {
+
+            String password = bCryptPasswordEncoder.encode("123456");
+
+            LocalAccount localAccount = LocalAccount.builder()
+                    .password(password)
+                    .build();
+
+            User user = User.builder()
+                    .email("view_count_test" + i + "@gmail.com")
+                    .name("테스트유저이름" + i)
+                    .nickname("view_test" + i)
+                    .gender(MAN)
+                    .status(ACTIVE)
+                    .localAccount(localAccount)
+                    .role(UserRole.USER)
+                    .profileImageUrl(i + "번유저 썸네일 url")
+                    .build();
+
+            users.add(user);
+        }
+        users = userRepository.saveAll(users);
+
+        Location location = Location
+                .of(new AddressName("address_name",
+                                "1depth_name",
+                                "2depth_name",
+                                "3depth_name"),
+                        new RegionCode(0, 0),
+                        new Coordinates(new BigDecimal("0.0"), new BigDecimal("0.0")));
+
+
+        gathering = Gathering.builder()
+                .organizerId(users.get(0).getId())
+                .title("조회수 동시성 테스트")
+                .description("재밌게 달려봅시다.")
+                .appointedAt(LocalDateTime.now().plusDays(2))
+                .deadline(LocalDateTime.now().plusDays(1))
+                .concept(RunningConcept.HEALTH)
+                .goalDistance(GoalDistance.FREE)
+                .thumbnailUrl("모임 썸네일")
+                .hits(0L)
+                .location(location)
+                .status(NORMAL)
+                .maxNumber(100)
+                .currentNumber(0)
+                .gatheringType(GENERAL)
+                .build();
+
+        gathering.addMember(users.get(0), ORGANIZER);
+        gathering.updateCurrentNumber(1);
+
+        gathering = gatheringRepository.save(gathering);
+
+        gatheringMemberCount = gatheringMemberCountRepository
+                .save(GatheringMemberCount.from(gathering));
+    }
+
+    // Gathering 하나
+    // 서로 다른 유저 100명
+
+    @DisplayName("100개 요청")
+    @Test
+    void addGatheringViewRecord() throws InterruptedException {
+        int threadCount = users.size();
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int userIdx = i; // 자바의 람다와 익명 클래스 내부에서 사용되는 변수는 final 또는 effectively final 이어야 함
+
+            executorService.submit(() -> {
+                try {
+                    gatheringService.hitGathering(users.get(userIdx).getId(), gathering.getId());
+
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Gathering findGathering = gatheringRepository
+                .findById(gathering.getId()).orElseThrow();
+
+        int hitCount = gatheringViewRecordRepository
+                .countByGatheringId(findGathering.getId());
+
+        assertEquals(users.size(), findGathering.getHits());
+        assertEquals(users.size(), hitCount);
+    }
+
+    @DisplayName("참가신청 99개 요청 (주최자 포함 100개)")
+    @Test
+    void addGatheringMember() throws InterruptedException {
+        int threadCount = users.size();
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int userIdx = i; // 자바의 람다와 익명 클래스 내부에서 사용되는 변수는 final 또는 effectively final 이어야 함
+
+            executorService.submit(() -> {
+                try {
+                    gatheringService.participateGathering(users.get(userIdx).getId(), gathering.getId());
+
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        Gathering findGathering = gatheringRepository
+                .findById(gathering.getId()).orElseThrow();
+
+        int memberCount = gatheringMemberRepository
+                .countByGatheringId(findGathering.getId());
+
+        /**
+         * Gathering 의 조회수 기능은 낙관적 락을 적용해볼려고, Gathering 에  @Version 를 적용했었는데,
+         * 이 때, 참가 기능이 제대로 동작하지 않는다.
+         * 비관적 락을 적용해서 가져온 GatheringMemberCount 도 동시성 제어 자체가 안되고있다. (이건 다른 엔티티인데, 왜인지..?)
+         * @Version 을 적용하지않으면 의도한 대로 동작한다.
+         */
+        GatheringMemberCount findGatheringMemberCount = gatheringMemberCountRepository.findByGatheringIdWithPessimisticLock(findGathering.getId())
+                .orElseThrow(() -> new GatheringException(GATHERING_MEMBER_COUNT_NOT_FOUND));
+
+
+        assertEquals(users.size(), findGatheringMemberCount.getCurrentNumber());
+        assertEquals(users.size(), findGathering.getCurrentNumber());
+        assertEquals(users.size(), memberCount);
+    }
+
+}


### PR DESCRIPTION
## 🔎 작업 내용

- **모임 상세 조회 리팩토링**
  -  수정사항: 0d5f0d79
- **모임 상세 조회 조회수 기능 구현**
  -  조회수의 경우 낙관적 락을 적용해보려했으나, 참가 기능에 영향이 생겨서, 조회수도 비관적 락을 적용하였음
     - GatheringServiceLockTest  
- **조회수, 참가 기능 동시성 테스트코드 추가**
- **참가/참가 취소 리팩토링**
  - #137 에서 잘못 알고 있는 부분들이 많은 듯함
  -  수정사항: 13131295
  <br/>

성능 & 코드의 구조가 바람직한지는 제치고, 일단 동시성제어가 되게끔은 해놨습니다.

## 🔧 리뷰 요구사항
> 저번 주에 끝냈어야 했는데, 일이 생겨서 너무 늦게 pr 올립니다. 죄송합니다


<br/>
