### PR TITLE
♻️Refactor: image 업로드 관련 리팩토링, 에러 해결

### DIFF
--- a/src/main/java/com/runto/domain/gathering/api/GatheringController.java
+++ b/src/main/java/com/runto/domain/gathering/api/GatheringController.java
@@ -38,13 +38,12 @@ public class GatheringController {
 
     @Operation(summary = "이벤트 개최신청 (이벤트 모임 등록)")
     @PostMapping("/events")
-    public ResponseEntity<Void> requestEventGatheringHosting(
+    public ResponseEntity<CreateGatheringResponse> requestEventGatheringHosting(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody CreateGatheringRequest request) {
 
-        log.info("userId = {}", userDetails.getUserId());
-        gatheringService.requestEventGatheringHosting(userDetails.getUserId(), request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(gatheringService
+                .requestEventGatheringHosting(userDetails.getUserId(), request));
     }
 
     @Operation(summary = "모임 상세조회 [일반모임, 이벤트모임]") // 같이 쓰게 된 이유는 pr 참조

--- a/src/main/java/com/runto/domain/image/application/ImageService.java
+++ b/src/main/java/com/runto/domain/image/application/ImageService.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+import static com.runto.domain.image.application.S3ImageService.*;
 import static com.runto.global.exception.ErrorCode.INVALID_FILE;
 
 @Slf4j
@@ -25,7 +26,7 @@ public class ImageService {
 
         log.info("모임글 이미지 등록 서비스 진입");
 
-        if (uploadRequest == null){
+        if (uploadRequest == null) {
             throw new ImageException(INVALID_FILE);
         }
 
@@ -55,14 +56,15 @@ public class ImageService {
 
     public ImageUrlDto updateUserProfile(Long userId, MultipartFile newImageFile, String oldImageUrl) {
 
-        s3ImageService.deleteS3Object(oldImageUrl, "temp/"); // TODO 나중에 이미지 버그 수정 및 리팩토링 때 수정될 수도 있음
+        s3ImageService.deleteS3Object(oldImageUrl, PERMANENT_STORE_PREFIX);
 
         if (newImageFile == null || newImageFile.isEmpty()) {
             return new ImageUrlDto(null, 0);
         }
 
-        return s3ImageService.uploadContentImages(
-                List.of(new ImageDto(newImageFile, 0)),
-                        String.format("profile[%s]", userId)).get(0);
+        return s3ImageService.uploadImage(PERMANENT_STORE_PREFIX,
+                new ImageDto(newImageFile, 0),
+                String.format("profile[%s]", userId));
+
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- ### 이미지 정식경로 이동 메서드 에러 해결
 모임 글 등록이 성공적으로 save 되면, 
 ``` 
// s3 temp 경로에 있던 이미지파일들을 정식 경로에 옮기기
        imageService.moveImageFromTempToPermanent(request.getImageRegisterResponse().getContentImageUrls());
```

```
    //s3의 temp/ 폴더에 있던 파일을 정식폴더에 복사한 후 삭제
    public void moveImageProcess(String imageUrl) {

        String imageName = extractImageName(imageUrl);

        validateUpload(TEMPORARY_STORE_PREFIX + imageName);

        copyS3ObjectToNewPath(imageName, TEMPORARY_STORE_PREFIX, PERMANENT_STORE_PREFIX);
        deleteS3ObjectFromImageName(imageName, TEMPORARY_STORE_PREFIX);
    }
```

에서 ``copyS3ObjectToNewPath`` 에서 자꾸 에러가 발생해서, 주석처리 하였었음.
key 값이 틀리지도 않았고, null 이 아님에도, 자꾸 key가 null 이라는 메세지만 나오고, 검색해도 원하는 답이 나오질 않아서, 
에러해결을 보류해뒀었던 상태

원인은 destinationBucket 이 누락됐기 때문
 (버킷을 한 개만 써봐서, 이상한 고정관념에 갇혀서, 당시에 발견을 못 했던 것 같다. 사실, CopyObjectRequest 의 빌더에 뭐가 있는지만 제대로 살펴봤어도 금방 해결했었을텐데 )

### 수정 한 코드
```
    public void copyS3ObjectToNewPath(String imageName, String beforePath, String newPath) {

        CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
                .sourceBucket(bucketName)
                .sourceKey(beforePath + imageName)
                .destinationBucket(bucketName)
                .destinationKey(newPath + imageName)
                .acl(ObjectCannedACL.PUBLIC_READ)
                .build();

        s3Client.copyObject(copyObjectRequest);
    }
```

- ### s3 이미지 서비스 일부 메서드 예외처리 수정 
- ### 프로필 이미지 등록까지 사용할 수 있게끔 업로드 메서드에  저장경로 접두사를 받게끔 수정

