### PR TITLE
:bug: Fix(CHAT): GroupChatService 모임 참여중인지 확인하는 조건문 수정

### DIFF
--- a/src/main/java/com/runto/domain/chat/application/GroupChatService.java
+++ b/src/main/java/com/runto/domain/chat/application/GroupChatService.java
@@ -58,7 +58,7 @@ public class GroupChatService {
         GroupChatRoom groupChatRoom = groupChatRoomRepository.findByGatheringId(gatheringId);
 
         //모임에 참여 중인지 확인
-        if (gatheringMemberRepository.existsGatheringMemberByGatheringIdAndUserId(gatheringId,userId)){
+        if (!gatheringMemberRepository.existsGatheringMemberByGatheringIdAndUserId(gatheringId,userId)){
             throw new ChatException(ErrorCode.GATHERING_MEMBER_NOT_FOUND);
         }
 


### PR DESCRIPTION

## 🔎 작업 내용
GroupChatService 모임 참여중인지 확인하는 조건문이 반대로 되어있어서 에러가 나는 오류 수정

  <br/>

## 이미지 첨부 (선)



<br/>

## 🔧 리뷰 요구사항



<br/>
