### PR TITLE
:bug: Fix(CHAT): 핸드셰이크 과정에서 쿠키 가져올때 쿠키가 없을때의 처리

### DIFF
--- a/src/main/java/com/runto/domain/chat/config/CustomHttpSessionHandShakeInterceptor.java
+++ b/src/main/java/com/runto/domain/chat/config/CustomHttpSessionHandShakeInterceptor.java
@@ -20,6 +20,9 @@ public class CustomHttpSessionHandShakeInterceptor implements HandshakeIntercept
         if(request instanceof ServletServerHttpRequest servletRequest){
             HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
             Cookie[] cookies = httpServletRequest.getCookies();
+            if (cookies == null) {
+                return true;
+            }
             for (Cookie cookie : cookies){
                 if ("Authorization".equals(cookie.getName())){
                     log.info("CustomHttpSessionHandShakeInterceptor Cookie Authorization = {}",cookie.getValue());


### PR DESCRIPTION

  
  <br/>

## 🔎 작업 내용
핸드셰이크 과정에서 쿠키 가져올때 쿠키가 없을때 반복문에서 런타임 에러가 발생하지 않도록 처리

  <br/>

## 이미지 첨부 (선)


<br/>

## 🔧 리뷰 요구사항



<br/>
